### PR TITLE
Meeting 초기 설정 수정

### DIFF
--- a/src/main/java/com/example/momo/domain/meetings/entity/Meeting.java
+++ b/src/main/java/com/example/momo/domain/meetings/entity/Meeting.java
@@ -69,7 +69,7 @@ public class Meeting extends BaseEntity {
 	@Column(nullable = false, name = "longitude")
 	private Double longitude;
 
-	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+	@OneToMany(cascade = {CascadeType.PERSIST})
 	@JoinColumn(name = "meeting_id")
 	private List<MeetingParticipant> participants = new ArrayList<>();
 

--- a/src/main/java/com/example/momo/domain/meetings/entity/Meeting.java
+++ b/src/main/java/com/example/momo/domain/meetings/entity/Meeting.java
@@ -1,10 +1,13 @@
 package com.example.momo.domain.meetings.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.example.momo.domain.common.entity.BaseEntity;
 import com.example.momo.domain.meetings.enums.MeetingStatus;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,6 +15,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -63,6 +68,10 @@ public class Meeting extends BaseEntity {
 
 	@Column(nullable = false, name = "longitude")
 	private Double longitude;
+
+	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+	@JoinColumn(name = "meeting_id")
+	private List<MeetingParticipant> participants = new ArrayList<>();
 
 	@Column(nullable = false, name = "participation_fee")
 	private int participationFee = 0;

--- a/src/main/java/com/example/momo/domain/meetings/entity/Meeting.java
+++ b/src/main/java/com/example/momo/domain/meetings/entity/Meeting.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,9 +23,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-public class Meetings extends BaseEntity {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Meeting extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -60,7 +61,7 @@ public class Meetings extends BaseEntity {
 	@Column(nullable = false, name = "latitude")
 	private Double latitude;
 
-	@Column(nullable = false, name = "longititude")
+	@Column(nullable = false, name = "longitude")
 	private Double longitude;
 
 	@Column(nullable = false, name = "participation_fee")

--- a/src/main/java/com/example/momo/domain/meetings/entity/MeetingParticipant.java
+++ b/src/main/java/com/example/momo/domain/meetings/entity/MeetingParticipant.java
@@ -11,14 +11,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Table(name = "meeting_participants")
 @Getter
 @Entity
-@NoArgsConstructor
-public class MeetingParticipants extends BaseCreateEntity {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetingParticipant extends BaseCreateEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,7 +27,7 @@ public class MeetingParticipants extends BaseCreateEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(nullable = false, name = "meeting_id")
-	private Meetings meeting;
+	private Meeting meeting;
 
 	@Column(nullable = false, name = "user_id")
 	private Long userId;

--- a/src/main/java/com/example/momo/domain/meetings/entity/MeetingParticipant.java
+++ b/src/main/java/com/example/momo/domain/meetings/entity/MeetingParticipant.java
@@ -4,12 +4,9 @@ import com.example.momo.domain.common.entity.BaseCreateEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -25,9 +22,8 @@ public class MeetingParticipant extends BaseCreateEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(nullable = false, name = "meeting_id")
-	private Meeting meeting;
+	@Column(nullable = false, name = "meeting_id")
+	private Long meeting;
 
 	@Column(nullable = false, name = "user_id")
 	private Long userId;


### PR DESCRIPTION
- Table Name 복수형 -> 단수형
- DB 칼럼명 오타 수정 (longititude -> longitude)
- 동일 컨텍스트 안에서 더욱 객체지향적인 코드를 작성하기 위해 에그리거트 루트만을 통해 하위 에그리거트 데이터를 처리하도록 연관관계 수정