### PR TITLE
사용자 정보 수정 API, 평가 등록, 유저 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/example/momo/domain/user/api/UserController.java
+++ b/src/main/java/com/example/momo/domain/user/api/UserController.java
@@ -1,7 +1,15 @@
 package com.example.momo.domain.user.api;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.example.momo.domain.common.dto.ApiResponse;
+import com.example.momo.domain.user.application.UserService;
+import com.example.momo.domain.user.domain.dto.UserInfoResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -9,4 +17,24 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
+
+	private final UserService userService;
+
+	// 특정 사용자 정보 조회
+	@GetMapping("{userId}")
+	public ResponseEntity<ApiResponse<UserInfoResponseDto>> getUserInfo(
+		@PathVariable Long userId
+	) {
+		UserInfoResponseDto response = userService.getUserById(userId);
+		return ResponseEntity.ok(ApiResponse.success("사용자 정보를 조회했습니다.", response));
+	}
+
+	// 현재 로그인안 사용자 정보 조회 (추후에 수정 예정)
+	@GetMapping("/me")
+	public ResponseEntity<ApiResponse<UserInfoResponseDto>> getCurrentUser(
+		@RequestHeader("user_id") Long currentUserId // TODO : 임시로 설정
+	) {
+		UserInfoResponseDto response = userService.getCurrentUser(currentUserId);
+		return ResponseEntity.ok(ApiResponse.success("내 정보를 조회했습니다.", response));
+	}
 }

--- a/src/main/java/com/example/momo/domain/user/api/UserController.java
+++ b/src/main/java/com/example/momo/domain/user/api/UserController.java
@@ -2,15 +2,24 @@ package com.example.momo.domain.user.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.momo.domain.common.dto.ApiResponse;
 import com.example.momo.domain.user.application.UserService;
+import com.example.momo.domain.user.domain.User;
+import com.example.momo.domain.user.domain.dto.UserCategoryUpdateRequestDto;
+import com.example.momo.domain.user.domain.dto.UserCategoryUpdateResponseDto;
+import com.example.momo.domain.user.domain.dto.UserEmailUpdateRequestDto;
 import com.example.momo.domain.user.domain.dto.UserInfoResponseDto;
+import com.example.momo.domain.user.domain.dto.UserNicknameUpdateRequestDto;
+import com.example.momo.domain.user.domain.dto.UserPasswordUpdateRequestDto;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -36,5 +45,46 @@ public class UserController {
 	) {
 		UserInfoResponseDto response = userService.getCurrentUser(currentUserId);
 		return ResponseEntity.ok(ApiResponse.success("내 정보를 조회했습니다.", response));
+	}
+
+	// 내 관심 카테고리 수정
+	@PatchMapping("/me/categories")
+	public ResponseEntity<ApiResponse<UserCategoryUpdateResponseDto>> updateMyCategories(
+		@RequestHeader("user_id") Long currentUserId, // TODO : 임시로 설정
+		@Valid @RequestBody UserCategoryUpdateRequestDto request
+	) {
+		User user = userService.updateUserCategories(currentUserId, request.categoryIds());
+		UserCategoryUpdateResponseDto response = new UserCategoryUpdateResponseDto(user);
+		return ResponseEntity.ok(ApiResponse.success("내 관심 카테고리가 수정되었습니다.", response));
+	}
+
+	// 내 비밀번호 수정
+	@PatchMapping("/me/password")
+	public ResponseEntity<ApiResponse<Void>> updateMyPassword(
+		@RequestHeader("user_id") Long currentUserId, // TODO : 임시로 설정
+		@Valid @RequestBody UserPasswordUpdateRequestDto request
+	) {
+		userService.updatePassword(currentUserId, request);
+		return ResponseEntity.ok(ApiResponse.success("비밀번호가 변경되었습니다.", null));
+	}
+
+	// 내 닉네임 수정
+	@PatchMapping("/me/nickname")
+	public ResponseEntity<ApiResponse<Void>> updateMyNickname(
+		@RequestHeader("user_id") Long currentUserId, // TODO : 임시로 설정
+		@Valid @RequestBody UserNicknameUpdateRequestDto request
+	) {
+		userService.updateNickname(currentUserId, request);
+		return ResponseEntity.ok(ApiResponse.success("닉네임이 변경되었습니다.", null));
+	}
+
+	// 내 이메일 수정
+	@PatchMapping("/me/email")
+	public ResponseEntity<ApiResponse<Void>> updateMyEmail(
+		@RequestHeader("user_id") Long currentUserId, // TODO : 임시로 설정
+		@Valid @RequestBody UserEmailUpdateRequestDto request
+	) {
+		userService.updateEmail(currentUserId, request);
+		return ResponseEntity.ok(ApiResponse.success("이메일이 변경되었습니다.", null));
 	}
 }

--- a/src/main/java/com/example/momo/domain/user/application/UserService.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserService.java
@@ -1,5 +1,11 @@
 package com.example.momo.domain.user.application;
 
+import com.example.momo.domain.user.domain.dto.UserInfoResponseDto;
+
 public interface UserService {
+
+	UserInfoResponseDto getUserById(Long userId);
+
+	UserInfoResponseDto getCurrentUser(Long CurrentUserId);
 
 }

--- a/src/main/java/com/example/momo/domain/user/application/UserService.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserService.java
@@ -7,6 +7,7 @@ import com.example.momo.domain.user.domain.dto.UserEmailUpdateRequestDto;
 import com.example.momo.domain.user.domain.dto.UserInfoResponseDto;
 import com.example.momo.domain.user.domain.dto.UserNicknameUpdateRequestDto;
 import com.example.momo.domain.user.domain.dto.UserPasswordUpdateRequestDto;
+import com.example.momo.domain.user.domain.dto.UserRatingCreateRequestDto;
 
 public interface UserService {
 
@@ -24,4 +25,5 @@ public interface UserService {
 
 	void updateEmail(Long userId, UserEmailUpdateRequestDto request);
 
+	void createUserRating(Long reviewerId, Long targetUserId, UserRatingCreateRequestDto request);
 }

--- a/src/main/java/com/example/momo/domain/user/application/UserService.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserService.java
@@ -1,11 +1,27 @@
 package com.example.momo.domain.user.application;
 
+import java.util.List;
+
+import com.example.momo.domain.user.domain.User;
+import com.example.momo.domain.user.domain.dto.UserEmailUpdateRequestDto;
 import com.example.momo.domain.user.domain.dto.UserInfoResponseDto;
+import com.example.momo.domain.user.domain.dto.UserNicknameUpdateRequestDto;
+import com.example.momo.domain.user.domain.dto.UserPasswordUpdateRequestDto;
 
 public interface UserService {
+
+	User validateAndGetUser(Long userId);
 
 	UserInfoResponseDto getUserById(Long userId);
 
 	UserInfoResponseDto getCurrentUser(Long CurrentUserId);
+
+	User updateUserCategories(Long userId, List<Integer> categoryIds);
+
+	void updatePassword(Long userId, UserPasswordUpdateRequestDto request);
+
+	void updateNickname(Long userId, UserNicknameUpdateRequestDto request);
+
+	void updateEmail(Long userId, UserEmailUpdateRequestDto request);
 
 }

--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -1,10 +1,16 @@
 package com.example.momo.domain.user.application;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.momo.domain.user.domain.User;
+import com.example.momo.domain.user.domain.UserCategory;
+import com.example.momo.domain.user.domain.dto.UserEmailUpdateRequestDto;
 import com.example.momo.domain.user.domain.dto.UserInfoResponseDto;
+import com.example.momo.domain.user.domain.dto.UserNicknameUpdateRequestDto;
+import com.example.momo.domain.user.domain.dto.UserPasswordUpdateRequestDto;
 import com.example.momo.domain.user.exception.UserException;
 import com.example.momo.domain.user.infra.UserRepository;
 
@@ -29,5 +35,80 @@ public class UserServiceImpl implements UserService {
 	@Transactional(readOnly = true)
 	public UserInfoResponseDto getCurrentUser(Long currentUserId) {
 		return getUserById(currentUserId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public User validateAndGetUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(UserException::userNotFound);
+	}
+
+	@Override
+	@Transactional
+	public User updateUserCategories(Long userId, List<Integer> categoryIds) {
+		try {
+			User user = validateAndGetUser(userId);
+
+			// 서비스에서 직접 카테고리 업데이트 처리
+			user.getCategories().clear();
+			categoryIds.forEach(categoryId ->
+				user.getCategories().add(new UserCategory(categoryId))
+			);
+
+			// JPA 더티체킹으로 자동 업데이트
+			return user;
+		} catch (UserException e) {
+			// UserException은 그대로 전파
+			throw e;
+		} catch (Exception e) {
+			// 기타 예외(DB 제약조건 위반 등)는 카테고리 관련 예외로 변환
+			throw UserException.invalidCategoryIds();
+		}
+	}
+
+	@Override
+	@Transactional
+	public void updatePassword(Long userId, UserPasswordUpdateRequestDto request) {
+		User user = validateAndGetUser(userId);
+
+		// 서비스에서 현재 비밀번호 확인 (TODO: 암호화된 비밀번호와 비교)
+		if (!user.getPassword().equals(request.currentPassword())) {
+			throw UserException.passwordMismatch();
+		}
+
+		if (!request.newPassword().equals(request.confirmPassword())) {
+			throw UserException.passwordConfirmMismatch();
+		}
+
+		user.updatePassword(request.newPassword());
+	}
+
+	@Override
+	@Transactional
+	public void updateNickname(Long userId, UserNicknameUpdateRequestDto request) {
+		User user = validateAndGetUser(userId);
+
+		if (userRepository.existsByNicknameAndIdNot(request.nickname(), userId)) {
+			throw UserException.duplicateNickname();
+		}
+		user.updateNickname(request.nickname());
+	}
+
+	@Override
+	@Transactional
+	public void updateEmail(Long userId, UserEmailUpdateRequestDto request) {
+		User user = validateAndGetUser(userId);
+
+		// 서비스에서 현재 비밀번호 확인 (TODO: 암호화된 비밀번호와 비교)
+		if (!user.getPassword().equals(request.currentPassword())) {
+			throw UserException.passwordMismatch();
+		}
+
+		if (userRepository.existsByEmailAndIdNot(request.email(), userId)) {
+			throw UserException.duplicateEmail();
+		}
+
+		user.updateEmail(request.email());
 	}
 }

--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -7,10 +7,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.momo.domain.user.domain.User;
 import com.example.momo.domain.user.domain.UserCategory;
+import com.example.momo.domain.user.domain.UserRating;
 import com.example.momo.domain.user.domain.dto.UserEmailUpdateRequestDto;
 import com.example.momo.domain.user.domain.dto.UserInfoResponseDto;
 import com.example.momo.domain.user.domain.dto.UserNicknameUpdateRequestDto;
 import com.example.momo.domain.user.domain.dto.UserPasswordUpdateRequestDto;
+import com.example.momo.domain.user.domain.dto.UserRatingCreateRequestDto;
 import com.example.momo.domain.user.exception.UserException;
 import com.example.momo.domain.user.infra.UserRepository;
 
@@ -110,5 +112,54 @@ public class UserServiceImpl implements UserService {
 		}
 
 		user.updateEmail(request.email());
+	}
+
+	@Override
+	@Transactional
+	public void createUserRating(Long reviewerId, Long targetUserId, UserRatingCreateRequestDto request) {
+		// 1. 자기 자신 평가 방지
+		if (reviewerId.equals(targetUserId)) {
+			throw UserException.cannotRateSelf();
+		}
+
+		// 2. 평가자 존재 확인
+		User reviewer = validateAndGetUser(reviewerId);
+
+		// 3. 평가 대상자 존재 확인
+		User targetUser = userRepository.findById(targetUserId)
+			.orElseThrow(UserException::targetUserNotFound);
+
+		// 4. 같은 모임 참가 여부 확인
+		// TODO: Meeting 도메인과 연동하여 실제 검증 로직 구현
+		validateSameMeetingParticipants(reviewerId, targetUserId, request.meetingId());
+
+		// 5. 중복 평가 확인 - targetUser의 ratings에서 확인
+		boolean alreadyRated = targetUser.getRatings().stream()
+			.anyMatch(rating ->
+				rating.getReviewerId().equals(reviewerId) &&
+					rating.getMeetingId().equals(request.meetingId())
+			);
+
+		if (alreadyRated) {
+			throw UserException.duplicateRating();
+		}
+
+		// 6. 평가 생성 및 targetUser의 ratings에 추가
+		UserRating userRating = new UserRating(
+			reviewerId,
+			request.meetingId(),
+			request.ratingScore()
+		);
+
+		// User 애그리거트를 통해 평가 추가
+		targetUser.getRatings().add(userRating);
+		// JPA 더티체킹으로 자동 저장
+	}
+
+	private void validateSameMeetingParticipants(Long reviewerId, Long targetUserId, Long meetingId) {
+		// TODO: Meeting 도메인과 연동하여 실제 검증 로직 구현
+		// 현재는 임시로 모든 경우를 허용
+		// 실제 구현시에는 MeetingParticipant 테이블을 조회하여
+		// 두 사용자가 모두 해당 모임에 참가했는지 확인해야 함
 	}
 }

--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -1,10 +1,33 @@
 package com.example.momo.domain.user.application;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.momo.domain.user.domain.User;
+import com.example.momo.domain.user.domain.dto.UserInfoResponseDto;
+import com.example.momo.domain.user.exception.UserException;
+import com.example.momo.domain.user.infra.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public UserInfoResponseDto getUserById(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(UserException::userNotFound);
+
+		return new UserInfoResponseDto(user);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public UserInfoResponseDto getCurrentUser(Long currentUserId) {
+		return getUserById(currentUserId);
+	}
 }

--- a/src/main/java/com/example/momo/domain/user/domain/User.java
+++ b/src/main/java/com/example/momo/domain/user/domain/User.java
@@ -59,7 +59,6 @@ public class User extends BaseEntity {
 	}
 
 	// === 연관관계 (OneToMany 단방향) ===
-
 	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
 	@JoinColumn(name = "user_id")
 	private List<UserCategory> categories = new ArrayList<>();
@@ -74,7 +73,23 @@ public class User extends BaseEntity {
 	@JoinColumn(name = "target_user_id")
 	private List<UserRating> ratings = new ArrayList<>();
 
-	public void updateInfo(String nickname, String email) {
+	// === 업데이트 메서드들 ===
+	public void updateNickname(String nickname) {
+		this.nickname = nickname;
 	}
 
+	public void updateEmail(String email) {
+		this.email = email;
+	}
+
+	public void updatePassword(String password) {
+		this.password = password;
+	}
+
+	public void updateCategories(List<Integer> categoryIds) {
+		this.categories.clear();
+		categoryIds.forEach(categoryId ->
+			this.categories.add(new UserCategory(categoryId))
+		);
+	}
 }

--- a/src/main/java/com/example/momo/domain/user/domain/dto/UserCategoryUpdateRequestDto.java
+++ b/src/main/java/com/example/momo/domain/user/domain/dto/UserCategoryUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.momo.domain.user.domain.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserCategoryUpdateRequestDto(
+
+	@NotNull(message = "카테고리 ID 목록은 필수입니다.")
+	List<Integer> categoryIds
+) {
+}

--- a/src/main/java/com/example/momo/domain/user/domain/dto/UserCategoryUpdateResponseDto.java
+++ b/src/main/java/com/example/momo/domain/user/domain/dto/UserCategoryUpdateResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.momo.domain.user.domain.dto;
+
+import java.util.List;
+
+import com.example.momo.domain.user.domain.User;
+import com.example.momo.domain.user.domain.UserCategory;
+
+public record UserCategoryUpdateResponseDto(
+	List<Integer> categoryIds
+) {
+	public UserCategoryUpdateResponseDto(User user) {
+		this(user.getCategories().stream()
+			.map(UserCategory::getCategoryId)
+			.toList());
+	}
+}

--- a/src/main/java/com/example/momo/domain/user/domain/dto/UserEmailUpdateRequestDto.java
+++ b/src/main/java/com/example/momo/domain/user/domain/dto/UserEmailUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.momo.domain.user.domain.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserEmailUpdateRequestDto(
+
+	@Email(message = "유효한 이메일 형식이어야 합니다.")
+	@NotBlank(message = "이메일은 필수입니다.")
+	String email,
+
+	@NotBlank(message = "현재 비밀번호는 필수입니다.")
+	String currentPassword
+) {
+}

--- a/src/main/java/com/example/momo/domain/user/domain/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/example/momo/domain/user/domain/dto/UserInfoResponseDto.java
@@ -1,0 +1,39 @@
+package com.example.momo.domain.user.domain.dto;
+
+import java.util.List;
+
+import com.example.momo.domain.user.domain.User;
+import com.example.momo.domain.user.domain.UserCategory;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoResponseDto {
+	private Long id;
+	private String nickname;
+	private String email;
+	private Double score;
+	private Double latitude;
+	private Double longitude;
+	private List<Integer> categoryIds;
+	private int followingCount;
+	private int followerCount;
+	private int ratingCount;
+
+	public UserInfoResponseDto(User user) {
+		this.id = user.getId();
+		this.nickname = user.getNickname();
+		this.email = user.getEmail();
+		this.score = user.getScore();
+		this.latitude = user.getLatitude();
+		this.longitude = user.getLongitude();
+		this.categoryIds = user.getCategories().stream()
+			.map(UserCategory::getCategoryId)
+			.toList();
+		this.followingCount = user.getFollowings().size();
+		this.followerCount = 0; // 추후 팔로워 조회 로직 추가 필요
+		this.ratingCount = user.getRatings().size();
+	}
+}

--- a/src/main/java/com/example/momo/domain/user/domain/dto/UserNicknameUpdateRequestDto.java
+++ b/src/main/java/com/example/momo/domain/user/domain/dto/UserNicknameUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.momo.domain.user.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserNicknameUpdateRequestDto(
+
+	@NotBlank(message = "닉네임은 필수입니다.")
+	@Size(min = 2, max = 20, message = "닉네임은 2-20자 이내여야 합니다.")
+	String nickname
+) {
+}

--- a/src/main/java/com/example/momo/domain/user/domain/dto/UserPasswordUpdateRequestDto.java
+++ b/src/main/java/com/example/momo/domain/user/domain/dto/UserPasswordUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.momo.domain.user.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserPasswordUpdateRequestDto(
+
+	@NotBlank(message = "현재 비밀번호는 필수입니다.")
+	String currentPassword,
+
+	@NotBlank(message = "새 비밀번호는 필수입니다.")
+	@Size(min = 8, max = 20, message = "비밀번호는 8-20자 이내여야 합니다.")
+	String newPassword,
+
+	@NotBlank(message = "비밀번호 확인은 필수입니다.")
+	String confirmPassword
+) {
+}

--- a/src/main/java/com/example/momo/domain/user/domain/dto/UserRatingCreateRequestDto.java
+++ b/src/main/java/com/example/momo/domain/user/domain/dto/UserRatingCreateRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.momo.domain.user.domain.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record UserRatingCreateRequestDto(
+
+	@NotNull(message = "모임 ID는 필수입니다.")
+	Long meetingId,
+
+	@NotNull(message = "평점은 필수입니다.")
+	@Min(value = 1, message = "평점은 1점 이상이어야 합니다.")
+	@Max(value = 5, message = "평점은 5점 이하여야 합니다.")
+	Integer ratingScore
+) {
+}

--- a/src/main/java/com/example/momo/domain/user/exception/UserException.java
+++ b/src/main/java/com/example/momo/domain/user/exception/UserException.java
@@ -33,6 +33,24 @@ public class UserException extends RuntimeException {
 		return new UserException("DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT);
 	}
 
+	// === 평가 관련 예외 ===
+	public static UserException cannotRateSelf() {
+		return new UserException("CANNOT_RATE_SELF", "자기 자신을 평가할 수 없습니다.", HttpStatus.BAD_REQUEST);
+	}
+
+	public static UserException notSameMeetingParticipants() {
+		return new UserException("NOT_SAME_MEETING_PARTICIPANTS", "같은 모임에 참가한 사용자만 평가할 수 있습니다.",
+			HttpStatus.BAD_REQUEST);
+	}
+
+	public static UserException duplicateRating() {
+		return new UserException("DUPLICATE_RATING", "같은 모임에서 이미 해당 사용자를 평가했습니다.", HttpStatus.CONFLICT);
+	}
+
+	public static UserException targetUserNotFound() {
+		return new UserException("TARGET_USER_NOT_FOUND", "평가 대상자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+	}
+
 	private UserException(String errorCode, String message, HttpStatus httpStatus) {
 		super(message);
 		this.errorCode = errorCode;

--- a/src/main/java/com/example/momo/domain/user/exception/UserException.java
+++ b/src/main/java/com/example/momo/domain/user/exception/UserException.java
@@ -13,6 +13,26 @@ public class UserException extends RuntimeException {
 		return new UserException("USER_NOT_FOUND", "유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 	}
 
+	public static UserException invalidCategoryIds() {
+		return new UserException("INVALID_CATEGORY_IDS", "유효하지 않은 카테고리 ID가 포함되어 있습니다.", HttpStatus.BAD_REQUEST);
+	}
+
+	public static UserException passwordMismatch() {
+		return new UserException("PASSWORD_MISMATCH", "현재 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+	}
+
+	public static UserException passwordConfirmMismatch() {
+		return new UserException("PASSWORD_CONFIRM_MISMATCH", "새 비밀번호와 확인 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+	}
+
+	public static UserException duplicateNickname() {
+		return new UserException("DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT);
+	}
+
+	public static UserException duplicateEmail() {
+		return new UserException("DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT);
+	}
+
 	private UserException(String errorCode, String message, HttpStatus httpStatus) {
 		super(message);
 		this.errorCode = errorCode;

--- a/src/main/java/com/example/momo/domain/user/exception/UserException.java
+++ b/src/main/java/com/example/momo/domain/user/exception/UserException.java
@@ -1,4 +1,21 @@
 package com.example.momo.domain.user.exception;
 
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
 public class UserException extends RuntimeException {
+	private final String errorCode;
+	private final HttpStatus httpStatus;
+
+	public static UserException userNotFound() {
+		return new UserException("USER_NOT_FOUND", "유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+	}
+
+	private UserException(String errorCode, String message, HttpStatus httpStatus) {
+		super(message);
+		this.errorCode = errorCode;
+		this.httpStatus = httpStatus;
+	}
 }

--- a/src/main/java/com/example/momo/domain/user/exception/UserExceptionHandler.java
+++ b/src/main/java/com/example/momo/domain/user/exception/UserExceptionHandler.java
@@ -1,22 +1,38 @@
 package com.example.momo.domain.user.exception;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.example.momo.domain.common.dto.ApiResponse;
 
 @RestControllerAdvice(basePackages = "com.example.momo.domain.user")
 public class UserExceptionHandler {
 
 	@ExceptionHandler(UserException.class)
-	public ResponseEntity<Map<String, Object>> handleProductException(UserException e) {
-		Map<String, Object> response = new HashMap<>();
-		response.put("error", e.getErrorCode());
-		response.put("message", e.getMessage());
-		response.put("status", e.getHttpStatus().value());
-
+	public ResponseEntity<ApiResponse<Object>> handleUserException(UserException e) {
+		ApiResponse<Object> response = ApiResponse.fail(e.getMessage(), null);
 		return ResponseEntity.status(e.getHttpStatus()).body(response);
+	}
+
+	/**
+	 * DB 제약조건 위반 (외래키 제약조건 등)
+	 * 카테고리 ID, 모임 ID, 사용자 ID 등 다양한 경우에 발생 가능
+	 */
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity<ApiResponse<Object>> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+		ApiResponse<Object> response = ApiResponse.fail("잘못된 요청입니다. 유효하지 않은 데이터가 포함되어 있습니다.", null);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+	}
+
+	/**
+	 * 기타 예외
+	 */
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<Object>> handleException(Exception e) {
+		ApiResponse<Object> response = ApiResponse.fail("서버 오류가 발생했습니다.", null);
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
 	}
 }

--- a/src/main/java/com/example/momo/domain/user/exception/UserExceptionHandler.java
+++ b/src/main/java/com/example/momo/domain/user/exception/UserExceptionHandler.java
@@ -1,7 +1,22 @@
 package com.example.momo.domain.user.exception;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice(basePackages = "com.example.momo.domain.user")
 public class UserExceptionHandler {
+
+	@ExceptionHandler(UserException.class)
+	public ResponseEntity<Map<String, Object>> handleProductException(UserException e) {
+		Map<String, Object> response = new HashMap<>();
+		response.put("error", e.getErrorCode());
+		response.put("message", e.getMessage());
+		response.put("status", e.getHttpStatus().value());
+
+		return ResponseEntity.status(e.getHttpStatus()).body(response);
+	}
 }

--- a/src/main/java/com/example/momo/domain/user/infra/UserJpaRepository.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserJpaRepository.java
@@ -7,5 +7,7 @@ import com.example.momo.domain.user.domain.User;
 
 @Repository
 public interface UserJpaRepository extends JpaRepository<User, Long> {
+	boolean existsByEmail(String email);
 
+	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/momo/domain/user/infra/UserJpaRepository.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserJpaRepository.java
@@ -7,7 +7,8 @@ import com.example.momo.domain.user.domain.User;
 
 @Repository
 public interface UserJpaRepository extends JpaRepository<User, Long> {
-	boolean existsByEmail(String email);
 
-	boolean existsByNickname(String nickname);
+	boolean existsByEmailAndIdNot(String email, Long id);
+
+	boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/java/com/example/momo/domain/user/infra/UserRepository.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserRepository.java
@@ -7,7 +7,7 @@ import com.example.momo.domain.user.domain.User;
 public interface UserRepository {
 	Optional<User> findById(Long id);
 
-	boolean existsByEmail(String email);
+	boolean existsByEmailAndIdNot(String email, Long id);
 
-	boolean existsByNickname(String nickname);
+	boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/java/com/example/momo/domain/user/infra/UserRepository.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserRepository.java
@@ -1,5 +1,13 @@
 package com.example.momo.domain.user.infra;
 
-public interface UserRepository {
+import java.util.Optional;
 
+import com.example.momo.domain.user.domain.User;
+
+public interface UserRepository {
+	Optional<User> findById(Long id);
+
+	boolean existsByEmail(String email);
+
+	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/momo/domain/user/infra/UserRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserRepositoryImpl.java
@@ -1,6 +1,10 @@
 package com.example.momo.domain.user.infra;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
+
+import com.example.momo.domain.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -9,4 +13,19 @@ import lombok.RequiredArgsConstructor;
 public class UserRepositoryImpl implements UserRepository {
 
 	private final UserJpaRepository userJpaRepository;
+
+	@Override
+	public Optional<User> findById(Long id) {
+		return userJpaRepository.findById(id);
+	}
+
+	@Override
+	public boolean existsByEmail(String email) {
+		return userJpaRepository.existsByEmail(email);
+	}
+
+	@Override
+	public boolean existsByNickname(String nickname) {
+		return userJpaRepository.existsByNickname(nickname);
+	}
 }

--- a/src/main/java/com/example/momo/domain/user/infra/UserRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserRepositoryImpl.java
@@ -20,12 +20,12 @@ public class UserRepositoryImpl implements UserRepository {
 	}
 
 	@Override
-	public boolean existsByEmail(String email) {
-		return userJpaRepository.existsByEmail(email);
+	public boolean existsByEmailAndIdNot(String email, Long id) {
+		return userJpaRepository.existsByEmailAndIdNot(email, id);
 	}
 
 	@Override
-	public boolean existsByNickname(String nickname) {
-		return userJpaRepository.existsByNickname(nickname);
+	public boolean existsByNicknameAndIdNot(String nickname, Long id) {
+		return userJpaRepository.existsByNicknameAndIdNot(nickname, id);
 	}
 }


### PR DESCRIPTION
사용자 정보 수정 API (카테고리, 닉네임, 이메일, 비밀번호 각각 구현)
평가 등록 API
유저 정보 조회 API 구현 (내 정보, 상대방 정보 조회 각각 구현)

추후에 서비스레이어 수정예정, 지금은 단순히 구조만 잡아놨음.

현재는 점수계산 알고리즘 내부 API 구현 중. (평가 등록이 트리거로 작용하여 이 내부 API가 실시간으로 실행될 예정)