### PR TITLE
Meeting 기능 구현 V1

### DIFF
--- a/src/main/java/com/example/momo/MomoApplication.java
+++ b/src/main/java/com/example/momo/MomoApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-//@EnableJpaAuditing
+@EnableJpaAuditing
 public class MomoApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/momo/domain/meetings/application/MeetingCoreService.java
+++ b/src/main/java/com/example/momo/domain/meetings/application/MeetingCoreService.java
@@ -3,6 +3,7 @@ package com.example.momo.domain.meetings.application;
 import com.example.momo.domain.meetings.enums.MeetingStatus;
 import com.example.momo.domain.meetings.presentation.dto.request.MeetingCreateRequest;
 import com.example.momo.domain.meetings.presentation.dto.request.MeetingUpdateRequest;
+import com.example.momo.domain.meetings.presentation.dto.response.MeetingPagingResponse;
 import com.example.momo.domain.meetings.presentation.dto.response.MeetingResponse;
 
 public interface MeetingCoreService {
@@ -13,5 +14,9 @@ public interface MeetingCoreService {
 
 	MeetingResponse searchMeeting(Long meetingId);
 
-	MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status);
+	MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status, Long userId);
+
+	MeetingPagingResponse<MeetingResponse> getMeetings(String title, int page, int size);
+
+	void deleteMeeting(Long meetingId, Long userId);
 }

--- a/src/main/java/com/example/momo/domain/meetings/application/MeetingCoreServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meetings/application/MeetingCoreServiceImpl.java
@@ -1,13 +1,22 @@
 package com.example.momo.domain.meetings.application;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.momo.domain.meetings.domain.Meeting;
 import com.example.momo.domain.meetings.domain.MeetingRepository;
 import com.example.momo.domain.meetings.enums.MeetingStatus;
+import com.example.momo.domain.meetings.exception.MeetingException;
+import com.example.momo.domain.meetings.exception.MeetingExceptionCode;
 import com.example.momo.domain.meetings.presentation.dto.request.MeetingCreateRequest;
 import com.example.momo.domain.meetings.presentation.dto.request.MeetingUpdateRequest;
+import com.example.momo.domain.meetings.presentation.dto.response.MeetingPagingResponse;
 import com.example.momo.domain.meetings.presentation.dto.response.MeetingResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -31,27 +40,74 @@ public class MeetingCoreServiceImpl implements MeetingCoreService {
 	@Transactional
 	public MeetingResponse updateMeeting(MeetingUpdateRequest request, Long meetingId, Long userId) {
 
-		// TODO : 예외처리
-		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
-		meeting.updateMeeting(request, userId);
+		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
+			new MeetingException(MeetingExceptionCode.MEETING_NOT_FOUND));
+
+		if (!meeting.getHostUserId().equals(userId)) {
+			throw new MeetingException(MeetingExceptionCode.MEETING_FORBIDDEN);
+		}
+
+		meeting.updateMeeting(request);
+
 		return new MeetingResponse(meeting);
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public MeetingResponse searchMeeting(Long meetingId) {
 
-		// TODO : 예외처리
-		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
+		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
+			new MeetingException(MeetingExceptionCode.MEETING_NOT_FOUND));
 		return new MeetingResponse(meeting);
 	}
 
 	@Override
 	@Transactional
-	public MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status) {
+	public MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status, Long userId) {
 
-		// TODO : 예외처리
-		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
+		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
+			new MeetingException(MeetingExceptionCode.MEETING_NOT_FOUND));
+
+		if (!meeting.getHostUserId().equals(userId)) {
+			throw new MeetingException(MeetingExceptionCode.MEETING_FORBIDDEN);
+		}
+
 		meeting.updateStatus(status);
 		return new MeetingResponse(meeting);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public MeetingPagingResponse<MeetingResponse> getMeetings(String title, int page, int size) {
+
+		Pageable pageable = PageRequest
+			.of(page - 1, size, Sort.Direction.DESC, "createdAt");
+
+		Page<Meeting> meetingPage = meetingRepository.findAllByTitleContaining(title, pageable);
+
+		List<MeetingResponse> meetingResponses = meetingPage.stream()
+			.map(MeetingResponse::new)
+			.toList();
+
+		return new MeetingPagingResponse<>(
+			meetingResponses,
+			meetingPage.getTotalElements(),
+			meetingPage.getTotalPages(),
+			meetingPage.getNumber() + 1
+		);
+	}
+
+	@Override
+	@Transactional
+	public void deleteMeeting(Long meetingId, Long userId) {
+
+		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
+			new MeetingException(MeetingExceptionCode.MEETING_NOT_FOUND));
+
+		if (!meeting.getHostUserId().equals(userId)) {
+			throw new MeetingException(MeetingExceptionCode.MEETING_FORBIDDEN);
+		}
+
+		meeting.delete();
 	}
 }

--- a/src/main/java/com/example/momo/domain/meetings/application/MeetingService.java
+++ b/src/main/java/com/example/momo/domain/meetings/application/MeetingService.java
@@ -1,5 +1,17 @@
 package com.example.momo.domain.meetings.application;
 
-public interface MeetingCoreService {
+import com.example.momo.domain.meetings.enums.MeetingStatus;
+import com.example.momo.domain.meetings.presentation.dto.request.MeetingCreateRequest;
+import com.example.momo.domain.meetings.presentation.dto.request.MeetingUpdateRequest;
+import com.example.momo.domain.meetings.presentation.dto.response.MeetingResponse;
 
+public interface MeetingService {
+
+	MeetingResponse createMeeting(MeetingCreateRequest request, Long userId);
+
+	MeetingResponse updateMeeting(MeetingUpdateRequest request, Long meetingId, Long userId);
+
+	MeetingResponse searchMeeting(Long meetingId);
+
+	MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status);
 }

--- a/src/main/java/com/example/momo/domain/meetings/application/MeetingService.java
+++ b/src/main/java/com/example/momo/domain/meetings/application/MeetingService.java
@@ -3,6 +3,7 @@ package com.example.momo.domain.meetings.application;
 import com.example.momo.domain.meetings.enums.MeetingStatus;
 import com.example.momo.domain.meetings.presentation.dto.request.MeetingCreateRequest;
 import com.example.momo.domain.meetings.presentation.dto.request.MeetingUpdateRequest;
+import com.example.momo.domain.meetings.presentation.dto.response.MeetingPagingResponse;
 import com.example.momo.domain.meetings.presentation.dto.response.MeetingResponse;
 
 public interface MeetingService {
@@ -13,5 +14,9 @@ public interface MeetingService {
 
 	MeetingResponse searchMeeting(Long meetingId);
 
-	MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status);
+	MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status, Long userId);
+
+	MeetingPagingResponse<MeetingResponse> getMeetings(String title, int page, int size);
+
+	void deleteMeeting(Long meetingId, Long userId);
 }

--- a/src/main/java/com/example/momo/domain/meetings/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meetings/application/MeetingServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import com.example.momo.domain.meetings.enums.MeetingStatus;
 import com.example.momo.domain.meetings.presentation.dto.request.MeetingCreateRequest;
 import com.example.momo.domain.meetings.presentation.dto.request.MeetingUpdateRequest;
+import com.example.momo.domain.meetings.presentation.dto.response.MeetingPagingResponse;
 import com.example.momo.domain.meetings.presentation.dto.response.MeetingResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -35,9 +36,21 @@ public class MeetingServiceImpl implements MeetingService {
 	}
 
 	@Override
-	public MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status) {
+	public MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status, Long userId) {
 
-		return meetingCoreService.updateMeetingStatus(meetingId, status);
+		return meetingCoreService.updateMeetingStatus(meetingId, status, userId);
+	}
+
+	@Override
+	public MeetingPagingResponse<MeetingResponse> getMeetings(String title, int page, int size) {
+
+		return meetingCoreService.getMeetings(title, page, size);
+	}
+
+	@Override
+	public void deleteMeeting(Long meetingId, Long userId) {
+
+		meetingCoreService.deleteMeeting(meetingId, userId);
 	}
 
 }

--- a/src/main/java/com/example/momo/domain/meetings/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meetings/application/MeetingServiceImpl.java
@@ -32,7 +32,7 @@ public class MeetingServiceImpl implements MeetingService {
 	public MeetingResponse updateMeeting(MeetingUpdateRequest request, Long meetingId, Long userId) {
 
 		// TODO : 예외처리
-		Meeting meeting = meetingRepository.findByMeetingId(meetingId).orElseThrow();
+		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
 		meeting.updateMeeting(request, userId);
 		return new MeetingResponse(meeting);
 	}
@@ -41,7 +41,7 @@ public class MeetingServiceImpl implements MeetingService {
 	public MeetingResponse searchMeeting(Long meetingId) {
 
 		// TODO : 예외처리
-		Meeting meeting = meetingRepository.findByMeetingId(meetingId).orElseThrow();
+		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
 		return new MeetingResponse(meeting);
 	}
 
@@ -50,7 +50,7 @@ public class MeetingServiceImpl implements MeetingService {
 	public MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status) {
 
 		// TODO : 예외처리
-		Meeting meeting = meetingRepository.findByMeetingId(meetingId).orElseThrow();
+		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
 		meeting.updateStatus(status);
 		return new MeetingResponse(meeting);
 	}

--- a/src/main/java/com/example/momo/domain/meetings/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meetings/application/MeetingServiceImpl.java
@@ -1,7 +1,57 @@
 package com.example.momo.domain.meetings.application;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.momo.domain.meetings.domain.Meeting;
+import com.example.momo.domain.meetings.domain.MeetingRepository;
+import com.example.momo.domain.meetings.enums.MeetingStatus;
+import com.example.momo.domain.meetings.presentation.dto.request.MeetingCreateRequest;
+import com.example.momo.domain.meetings.presentation.dto.request.MeetingUpdateRequest;
+import com.example.momo.domain.meetings.presentation.dto.response.MeetingResponse;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
-public class MeetingCoreServiceImpl implements MeetingCoreService {
+@RequiredArgsConstructor
+public class MeetingServiceImpl implements MeetingService {
+
+	private final MeetingRepository meetingRepository;
+
+	@Override
+	@Transactional
+	public MeetingResponse createMeeting(MeetingCreateRequest request, Long userId) {
+
+		Meeting meeting = request.toMeeting(userId);
+		Meeting savedMeeting = meetingRepository.save(meeting);
+		return new MeetingResponse(savedMeeting);
+	}
+
+	@Override
+	@Transactional
+	public MeetingResponse updateMeeting(MeetingUpdateRequest request, Long meetingId, Long userId) {
+
+		// TODO : 예외처리
+		Meeting meeting = meetingRepository.findByMeetingId(meetingId).orElseThrow();
+		meeting.updateMeeting(request, userId);
+		return new MeetingResponse(meeting);
+	}
+
+	@Override
+	public MeetingResponse searchMeeting(Long meetingId) {
+
+		// TODO : 예외처리
+		Meeting meeting = meetingRepository.findByMeetingId(meetingId).orElseThrow();
+		return new MeetingResponse(meeting);
+	}
+
+	@Override
+	@Transactional
+	public MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status) {
+
+		// TODO : 예외처리
+		Meeting meeting = meetingRepository.findByMeetingId(meetingId).orElseThrow();
+		meeting.updateStatus(status);
+		return new MeetingResponse(meeting);
+	}
 }

--- a/src/main/java/com/example/momo/domain/meetings/domain/Meeting.java
+++ b/src/main/java/com/example/momo/domain/meetings/domain/Meeting.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.example.momo.domain.common.entity.BaseEntity;
 import com.example.momo.domain.meetings.enums.MeetingStatus;
+import com.example.momo.domain.meetings.presentation.dto.request.MeetingUpdateRequest;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -46,7 +47,7 @@ public class Meeting extends BaseEntity {
 	private String description;
 
 	@Column(name = "category_id")
-	private Long categoryId;
+	private int categoryId;
 
 	@Column(nullable = false, name = "current_participants_count")
 	private int currentParticipantsCount;
@@ -83,4 +84,23 @@ public class Meeting extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false, name = "status")
 	private MeetingStatus status; // 모집중, 모집완료
+
+	public void updateMeeting(MeetingUpdateRequest request, Long userId) {
+		this.title = request.getTitle();
+		this.description = request.getDescription();
+		this.categoryId = request.getCategoryId();
+		this.maxParticipantsCount = request.getMaxParticipantsCount();
+		this.meetingDate = request.getMeetingDate();
+		this.meetingEndDate = request.getMeetingEndDate();
+		this.locationName = request.getLocationName();
+		this.latitude = request.getLatitude();
+		this.longitude = request.getLongitude();
+		this.minEnterScore = request.getMinEnterScore();
+		this.participationFee = request.getParticipationFee();
+		this.status = request.getStatus();
+	}
+
+	public void updateStatus(MeetingStatus status) {
+		this.status = status;
+	}
 }

--- a/src/main/java/com/example/momo/domain/meetings/domain/Meeting.java
+++ b/src/main/java/com/example/momo/domain/meetings/domain/Meeting.java
@@ -47,13 +47,13 @@ public class Meeting extends BaseEntity {
 	private String description;
 
 	@Column(name = "category_id")
-	private int categoryId;
+	private Integer categoryId;
 
 	@Column(nullable = false, name = "current_participants_count")
 	private int currentParticipantsCount;
 
 	@Column(nullable = false, name = "max_participants_count")
-	private int maxParticipantsCount;
+	private Integer maxParticipantsCount;
 
 	@Column(nullable = false, name = "meeting_date")
 	private LocalDateTime meetingDate;
@@ -78,14 +78,14 @@ public class Meeting extends BaseEntity {
 	private List<MeetingParticipant> participants = new ArrayList<>();
 
 	@Column(nullable = false, name = "participation_fee")
-	private int participationFee = 0;
+	private int participationFee;
 
 	// TODO : 추후 Converter 변경 고려
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false, name = "status")
 	private MeetingStatus status; // 모집중, 모집완료
 
-	public void updateMeeting(MeetingUpdateRequest request, Long userId) {
+	public void updateMeeting(MeetingUpdateRequest request) {
 		this.title = request.getTitle();
 		this.description = request.getDescription();
 		this.categoryId = request.getCategoryId();

--- a/src/main/java/com/example/momo/domain/meetings/domain/MeetingRepository.java
+++ b/src/main/java/com/example/momo/domain/meetings/domain/MeetingRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 public interface MeetingRepository {
 
-	Optional<Meeting> findByMeetingId(Long meetingId);
+	Optional<Meeting> findById(Long meetingId);
 
 	Meeting save(Meeting meeting);
 }

--- a/src/main/java/com/example/momo/domain/meetings/domain/MeetingRepository.java
+++ b/src/main/java/com/example/momo/domain/meetings/domain/MeetingRepository.java
@@ -1,4 +1,10 @@
 package com.example.momo.domain.meetings.domain;
 
+import java.util.Optional;
+
 public interface MeetingRepository {
+
+	Optional<Meeting> findByMeetingId(Long meetingId);
+
+	Meeting save(Meeting meeting);
 }

--- a/src/main/java/com/example/momo/domain/meetings/domain/MeetingRepository.java
+++ b/src/main/java/com/example/momo/domain/meetings/domain/MeetingRepository.java
@@ -2,9 +2,14 @@ package com.example.momo.domain.meetings.domain;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface MeetingRepository {
 
 	Optional<Meeting> findById(Long meetingId);
 
 	Meeting save(Meeting meeting);
+
+	Page<Meeting> findAllByTitleContaining(String title, Pageable pageable);
 }

--- a/src/main/java/com/example/momo/domain/meetings/exception/MeetingExceptionCode.java
+++ b/src/main/java/com/example/momo/domain/meetings/exception/MeetingExceptionCode.java
@@ -1,7 +1,8 @@
 package com.example.momo.domain.meetings.exception;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
 
 @Getter
 public enum MeetingExceptionCode {
@@ -10,7 +11,7 @@ public enum MeetingExceptionCode {
 
 	// 403
 	INSUFFICIENT_SCORE(HttpStatus.FORBIDDEN, "Insufficient score"),
-
+	MEETING_FORBIDDEN(HttpStatus.FORBIDDEN, "Meeting is forbidden"),
 	// 404
 	MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "Meeting not found"),
 	PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "Participant not found"),
@@ -21,7 +22,7 @@ public enum MeetingExceptionCode {
 	private final HttpStatus httpStatus;
 	private final String message;
 
-	MeetingExceptionCode (HttpStatus httpStatus, String message) {
+	MeetingExceptionCode(HttpStatus httpStatus, String message) {
 		this.httpStatus = httpStatus;
 		this.message = message;
 	}

--- a/src/main/java/com/example/momo/domain/meetings/infra/MeetingJpaRepository.java
+++ b/src/main/java/com/example/momo/domain/meetings/infra/MeetingJpaRepository.java
@@ -1,5 +1,9 @@
 package com.example.momo.domain.meetings.infra;
 
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +11,8 @@ import com.example.momo.domain.meetings.domain.Meeting;
 
 @Repository
 public interface MeetingJpaRepository extends JpaRepository<Meeting, Long> {
+	Optional<Meeting> findByIdAndIsDeletedFalse(Long id);
+
+	Page<Meeting> findAllByTitleContaining(String title, Pageable pageable);
 }
+

--- a/src/main/java/com/example/momo/domain/meetings/infra/MeetingJpaRepository.java
+++ b/src/main/java/com/example/momo/domain/meetings/infra/MeetingJpaRepository.java
@@ -13,6 +13,6 @@ import com.example.momo.domain.meetings.domain.Meeting;
 public interface MeetingJpaRepository extends JpaRepository<Meeting, Long> {
 	Optional<Meeting> findByIdAndIsDeletedFalse(Long id);
 
-	Page<Meeting> findAllByTitleContaining(String title, Pageable pageable);
+	Page<Meeting> findAllByTitleContainingAndIsDeletedFalse(String title, Pageable pageable);
 }
 

--- a/src/main/java/com/example/momo/domain/meetings/infra/MeetingRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meetings/infra/MeetingRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.example.momo.domain.meetings.infra;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.example.momo.domain.meetings.domain.Meeting;
@@ -17,11 +19,16 @@ public class MeetingRepositoryImpl implements MeetingRepository {
 
 	@Override
 	public Optional<Meeting> findById(Long id) {
-		return meetingJpaRepository.findById(id);
+		return meetingJpaRepository.findByIdAndIsDeletedFalse(id);
 	}
 
 	@Override
 	public Meeting save(Meeting meeting) {
 		return meetingJpaRepository.save(meeting);
+	}
+
+	@Override
+	public Page<Meeting> findAllByTitleContaining(String title, Pageable pageable) {
+		return meetingJpaRepository.findAllByTitleContaining(title, pageable);
 	}
 }

--- a/src/main/java/com/example/momo/domain/meetings/infra/MeetingRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meetings/infra/MeetingRepositoryImpl.java
@@ -16,7 +16,7 @@ public class MeetingRepositoryImpl implements MeetingRepository {
 	private final MeetingJpaRepository meetingJpaRepository;
 
 	@Override
-	public Optional<Meeting> findByMeetingId(Long id) {
+	public Optional<Meeting> findById(Long id) {
 		return meetingJpaRepository.findById(id);
 	}
 

--- a/src/main/java/com/example/momo/domain/meetings/infra/MeetingRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meetings/infra/MeetingRepositoryImpl.java
@@ -29,6 +29,6 @@ public class MeetingRepositoryImpl implements MeetingRepository {
 
 	@Override
 	public Page<Meeting> findAllByTitleContaining(String title, Pageable pageable) {
-		return meetingJpaRepository.findAllByTitleContaining(title, pageable);
+		return meetingJpaRepository.findAllByTitleContainingAndIsDeletedFalse(title, pageable);
 	}
 }

--- a/src/main/java/com/example/momo/domain/meetings/infra/MeetingRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meetings/infra/MeetingRepositoryImpl.java
@@ -1,7 +1,10 @@
 package com.example.momo.domain.meetings.infra;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
+import com.example.momo.domain.meetings.domain.Meeting;
 import com.example.momo.domain.meetings.domain.MeetingRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -11,4 +14,14 @@ import lombok.RequiredArgsConstructor;
 public class MeetingRepositoryImpl implements MeetingRepository {
 
 	private final MeetingJpaRepository meetingJpaRepository;
+
+	@Override
+	public Optional<Meeting> findByMeetingId(Long id) {
+		return meetingJpaRepository.findById(id);
+	}
+
+	@Override
+	public Meeting save(Meeting meeting) {
+		return meetingJpaRepository.save(meeting);
+	}
 }

--- a/src/main/java/com/example/momo/domain/meetings/presentation/controller/MeetingController.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/controller/MeetingController.java
@@ -1,6 +1,9 @@
 package com.example.momo.domain.meetings.presentation.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,16 +14,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.momo.domain.auth.dto.AuthUser;
 import com.example.momo.domain.common.dto.ApiResponse;
 import com.example.momo.domain.meetings.application.MeetingService;
 import com.example.momo.domain.meetings.enums.MeetingStatus;
 import com.example.momo.domain.meetings.presentation.dto.request.MeetingCreateRequest;
 import com.example.momo.domain.meetings.presentation.dto.request.MeetingUpdateRequest;
+import com.example.momo.domain.meetings.presentation.dto.response.MeetingPagingResponse;
 import com.example.momo.domain.meetings.presentation.dto.response.MeetingResponse;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 
+@Validated
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/v1/meetings")
@@ -30,11 +37,9 @@ public class MeetingController {
 
 	@PostMapping
 	public ResponseEntity<ApiResponse<MeetingResponse>> createMeeting(
-		@RequestBody @Valid MeetingCreateRequest request) {
+		@RequestBody @Valid MeetingCreateRequest request, @AuthenticationPrincipal AuthUser authUser) {
 
-		// TODO : 인증 개발 후 수정
-		Long userId = 1L;
-		MeetingResponse response = meetingService.createMeeting(request, userId);
+		MeetingResponse response = meetingService.createMeeting(request, authUser.getId());
 		return ResponseEntity.ok(ApiResponse.success("모임 생성이 성공적으로 완료되었습니다.", response));
 	}
 
@@ -47,35 +52,38 @@ public class MeetingController {
 
 	@PutMapping("/{meetingId}")
 	public ResponseEntity<ApiResponse<MeetingResponse>> updateMeeting(@PathVariable Long meetingId,
-		@RequestBody @Valid MeetingUpdateRequest request) {
+		@RequestBody @Valid MeetingUpdateRequest request, @AuthenticationPrincipal AuthUser authUser) {
 
-		// TODO : 인증 개발 후 수정
-		Long userId = 1L;
-		MeetingResponse response = meetingService.updateMeeting(request, meetingId, userId);
+		MeetingResponse response = meetingService.updateMeeting(request, meetingId, authUser.getId());
 		return ResponseEntity.ok(ApiResponse.success("모임 수정이 성공적으로 완료되었습니다.", response));
 	}
 
 	@PatchMapping("/{meetingId}")
 	public ResponseEntity<ApiResponse<MeetingResponse>> updateMeetingStatus(@PathVariable Long meetingId,
-		@RequestBody MeetingStatus status) {
+		@RequestBody MeetingStatus status, @AuthenticationPrincipal AuthUser authUser) {
 
-		// TODO : 인증 개발 후 수정
-		Long userId = 1L;
-		MeetingResponse response = meetingService.updateMeetingStatus(meetingId, status);
+		MeetingResponse response = meetingService.updateMeetingStatus(meetingId, status, authUser.getId());
 		return ResponseEntity.ok(ApiResponse.success("모임 상태 변경이 성공적으로 완료되었습니다.", response));
 	}
 
-	// TODO : 응답 형식 만들기
+	// TODO : 동적 필터 부분은 추후 queryDsl 추가 후 수정, 우선은 제목만 필터링 [status, meetingDate, 위도, 경도 등등]
 	@GetMapping
-	public ResponseEntity<ApiResponse<Void>> searchMeetings(
-		@RequestParam Long categoryId,
-		@RequestParam int page,
-		@RequestParam int size,
-		@RequestParam double latitude,
-		@RequestParam double longitude) {
+	public ResponseEntity<ApiResponse<MeetingPagingResponse<MeetingResponse>>> searchMeetings(
+		@RequestParam(defaultValue = "") String title,
+		@RequestParam(defaultValue = "1") @Min(1) int page,
+		@RequestParam(defaultValue = "10") @Min(5) int size
+	) {
 
-		return ResponseEntity.ok(ApiResponse.success("모임 목록 조회가 성공적으로 완료되었습니다.", null));
+		System.out.println(title);
+		MeetingPagingResponse<MeetingResponse> response = meetingService.getMeetings(title, page, size);
+		return ResponseEntity.ok(ApiResponse.success("모임 목록 조회가 성공적으로 완료되었습니다.", response));
 	}
 
-	// TODO : 삭제까지 구현 할 것
+	@DeleteMapping("/{meetingId}")
+	public ResponseEntity<ApiResponse<Void>> deleteMeeting(@PathVariable Long meetingId,
+		@AuthenticationPrincipal AuthUser authUser) {
+
+		meetingService.deleteMeeting(meetingId, authUser.getId());
+		return ResponseEntity.ok(ApiResponse.success("모임 삭제가 성공적으로 완료되었습니다.", null));
+	}
 }

--- a/src/main/java/com/example/momo/domain/meetings/presentation/controller/MeetingController.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/controller/MeetingController.java
@@ -14,41 +14,58 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.momo.domain.common.dto.ApiResponse;
 import com.example.momo.domain.meetings.application.MeetingService;
 import com.example.momo.domain.meetings.enums.MeetingStatus;
+import com.example.momo.domain.meetings.presentation.dto.request.MeetingCreateRequest;
+import com.example.momo.domain.meetings.presentation.dto.request.MeetingUpdateRequest;
+import com.example.momo.domain.meetings.presentation.dto.response.MeetingResponse;
 
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/v1/meetings")
-public class MeetingCoreController {
+public class MeetingController {
 
-	private final MeetingService meetingCoreService;
+	private final MeetingService meetingService;
 
 	@PostMapping
-	public ResponseEntity<ApiResponse<Void>> createMeeting() {
+	public ResponseEntity<ApiResponse<MeetingResponse>> createMeeting(
+		@RequestBody @Valid MeetingCreateRequest request) {
 
-		return ResponseEntity.ok(ApiResponse.success("모임 생성이 성공적으로 완료되었습니다.", null));
+		// TODO : 인증 개발 후 수정
+		Long userId = 1L;
+		MeetingResponse response = meetingService.createMeeting(request, userId);
+		return ResponseEntity.ok(ApiResponse.success("모임 생성이 성공적으로 완료되었습니다.", response));
 	}
 
 	@GetMapping("/{meetingId}")
-	public ResponseEntity<ApiResponse<Void>> searchMeeting(@PathVariable Long meetingId) {
+	public ResponseEntity<ApiResponse<MeetingResponse>> searchMeeting(@PathVariable Long meetingId) {
 
-		return ResponseEntity.ok(ApiResponse.success("모임 조회가 성공적으로 완료되었습니다.", null));
+		MeetingResponse response = meetingService.searchMeeting(meetingId);
+		return ResponseEntity.ok(ApiResponse.success("모임 조회가 성공적으로 완료되었습니다.", response));
 	}
 
 	@PutMapping("/{meetingId}")
-	public ResponseEntity<ApiResponse<Void>> updateMeeting(@PathVariable Long meetingId) {
+	public ResponseEntity<ApiResponse<MeetingResponse>> updateMeeting(@PathVariable Long meetingId,
+		@RequestBody @Valid MeetingUpdateRequest request) {
 
-		return ResponseEntity.ok(ApiResponse.success("모임 수정이 성공적으로 완료되었습니다.", null));
+		// TODO : 인증 개발 후 수정
+		Long userId = 1L;
+		MeetingResponse response = meetingService.updateMeeting(request, meetingId, userId);
+		return ResponseEntity.ok(ApiResponse.success("모임 수정이 성공적으로 완료되었습니다.", response));
 	}
 
 	@PatchMapping("/{meetingId}")
-	public ResponseEntity<ApiResponse<Void>> updateMeetingStatus(@PathVariable Long meetingId,
+	public ResponseEntity<ApiResponse<MeetingResponse>> updateMeetingStatus(@PathVariable Long meetingId,
 		@RequestBody MeetingStatus status) {
 
-		return ResponseEntity.ok(ApiResponse.success("모임 상태 변경이 성공적으로 완료되었습니다.", null));
+		// TODO : 인증 개발 후 수정
+		Long userId = 1L;
+		MeetingResponse response = meetingService.updateMeetingStatus(meetingId, status);
+		return ResponseEntity.ok(ApiResponse.success("모임 상태 변경이 성공적으로 완료되었습니다.", response));
 	}
 
+	// TODO : 응답 형식 만들기
 	@GetMapping
 	public ResponseEntity<ApiResponse<Void>> searchMeetings(
 		@RequestParam Long categoryId,
@@ -59,4 +76,6 @@ public class MeetingCoreController {
 
 		return ResponseEntity.ok(ApiResponse.success("모임 목록 조회가 성공적으로 완료되었습니다.", null));
 	}
+
+	// TODO : 삭제까지 구현 할 것
 }

--- a/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingCreateRequest.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingCreateRequest.java
@@ -1,0 +1,64 @@
+package com.example.momo.domain.meetings.presentation.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import com.example.momo.domain.meetings.domain.Meeting;
+import com.example.momo.domain.meetings.enums.MeetingStatus;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class MeetingCreateRequest {
+
+	@NotBlank(message = "제목은 필수 사항입니다.")
+	private String title;
+
+	@NotBlank(message = "설명은 필수 사항입니다.")
+	private String description;
+
+	private int categoryId;
+
+	@NotNull(message = "최대 참여자수는 필수 사항입니다.")
+	private int maxParticipantsCount;
+
+	@NotNull(message = "모임 날짜는 필수 사항입니다.")
+	private LocalDateTime meetingDate;
+
+	@NotNull(message = "모임 마감 날짜는 필수 사항입니다.")
+	private LocalDateTime meetingEndDate;
+
+	@NotBlank(message = "모임 위치는 필수 사항입니다.")
+	private String LocationName;
+
+	@NotNull(message = "위도는 필수 사항입니다.")
+	private Double latitude;
+
+	@NotNull(message = "경도는 필수 사항입니다.")
+	private Double longitude;
+
+	private Double minEnterScore;
+
+	private int participationFee;
+
+	public Meeting toMeeting(Long userId) {
+		return Meeting.builder()
+			.hostUserId(userId)
+			.title(this.title)
+			.description(this.description)
+			.categoryId(this.categoryId)
+			.currentParticipantsCount(1) // 기본값 1로 설정
+			.maxParticipantsCount(this.maxParticipantsCount)
+			.meetingDate(this.meetingDate)
+			.meetingEndDate(this.meetingEndDate)
+			.locationName(this.LocationName)
+			.latitude(this.latitude)
+			.longitude(this.longitude)
+			.minEnterScore(Optional.ofNullable(this.minEnterScore).orElse(0.0))
+			.participationFee(this.participationFee)
+			.status(MeetingStatus.IN_PROGRESS)
+			.build();
+	}
+}

--- a/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingCreateRequest.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingCreateRequest.java
@@ -19,10 +19,10 @@ public class MeetingCreateRequest {
 	@NotBlank(message = "설명은 필수 사항입니다.")
 	private String description;
 
-	private int categoryId;
+	private Integer categoryId;
 
 	@NotNull(message = "최대 참여자수는 필수 사항입니다.")
-	private int maxParticipantsCount;
+	private Integer maxParticipantsCount;
 
 	@NotNull(message = "모임 날짜는 필수 사항입니다.")
 	private LocalDateTime meetingDate;
@@ -31,7 +31,7 @@ public class MeetingCreateRequest {
 	private LocalDateTime meetingEndDate;
 
 	@NotBlank(message = "모임 위치는 필수 사항입니다.")
-	private String LocationName;
+	private String locationName;
 
 	@NotNull(message = "위도는 필수 사항입니다.")
 	private Double latitude;
@@ -53,7 +53,7 @@ public class MeetingCreateRequest {
 			.maxParticipantsCount(this.maxParticipantsCount)
 			.meetingDate(this.meetingDate)
 			.meetingEndDate(this.meetingEndDate)
-			.locationName(this.LocationName)
+			.locationName(this.locationName)
 			.latitude(this.latitude)
 			.longitude(this.longitude)
 			.minEnterScore(Optional.ofNullable(this.minEnterScore).orElse(0.0))

--- a/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingStatusUpdateRequest.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingStatusUpdateRequest.java
@@ -2,10 +2,12 @@ package com.example.momo.domain.meetings.presentation.dto.request;
 
 import com.example.momo.domain.meetings.enums.MeetingStatus;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class MeetingStatusUpdateRequest {
 
+	@NotBlank(message = "상태값은 필수입니다.")
 	private MeetingStatus status;
 }

--- a/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingStatusUpdateRequest.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingStatusUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.example.momo.domain.meetings.presentation.dto.request;
+
+import com.example.momo.domain.meetings.enums.MeetingStatus;
+
+import lombok.Getter;
+
+@Getter
+public class MeetingStatusUpdateRequest {
+
+	private MeetingStatus status;
+}

--- a/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingUpdateRequest.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingUpdateRequest.java
@@ -1,0 +1,46 @@
+package com.example.momo.domain.meetings.presentation.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.example.momo.domain.meetings.enums.MeetingStatus;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class MeetingUpdateRequest {
+
+	@NotBlank(message = "제목은 필수 사항입니다.")
+	private String title;
+
+	@NotBlank(message = "설명은 필수 사항입니다.")
+	private String description;
+
+	private int categoryId;
+
+	@NotNull(message = "최대 참여자수는 필수 사항입니다.")
+	private int maxParticipantsCount;
+
+	@NotNull(message = "모임 날짜는 필수 사항입니다.")
+	private LocalDateTime meetingDate;
+
+	@NotNull(message = "모임 마감 날짜는 필수 사항입니다.")
+	private LocalDateTime meetingEndDate;
+
+	@NotBlank(message = "모임 위치는 필수 사항입니다.")
+	private String LocationName;
+
+	@NotNull(message = "위도는 필수 사항입니다.")
+	private Double latitude;
+
+	@NotNull(message = "경도는 필수 사항입니다.")
+	private Double longitude;
+
+	private Double minEnterScore;
+
+	private int participationFee;
+
+	@NotNull(message = "상태는 필수 사항입니다.")
+	private MeetingStatus status;
+}

--- a/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingUpdateRequest.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/dto/request/MeetingUpdateRequest.java
@@ -17,7 +17,7 @@ public class MeetingUpdateRequest {
 	@NotBlank(message = "설명은 필수 사항입니다.")
 	private String description;
 
-	private int categoryId;
+	private Integer categoryId;
 
 	@NotNull(message = "최대 참여자수는 필수 사항입니다.")
 	private int maxParticipantsCount;

--- a/src/main/java/com/example/momo/domain/meetings/presentation/dto/response/MeetingPagingResponse.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/dto/response/MeetingPagingResponse.java
@@ -1,0 +1,16 @@
+package com.example.momo.domain.meetings.presentation.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MeetingPagingResponse<T> {
+
+	private List<T> data;
+	private Long total;
+	private int totalPage;
+	private int currentPage;
+}

--- a/src/main/java/com/example/momo/domain/meetings/presentation/dto/response/MeetingResponse.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/dto/response/MeetingResponse.java
@@ -14,7 +14,7 @@ public class MeetingResponse {
 	private final Long hostUserId;
 	private final String title;
 	private final String description;
-	private final int categoryId;
+	private final Integer categoryId;
 	private final int currentParticipantsCount;
 	private final int maxParticipantsCount;
 	private final LocalDateTime meetingDate;

--- a/src/main/java/com/example/momo/domain/meetings/presentation/dto/response/MeetingResponse.java
+++ b/src/main/java/com/example/momo/domain/meetings/presentation/dto/response/MeetingResponse.java
@@ -1,0 +1,50 @@
+package com.example.momo.domain.meetings.presentation.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.example.momo.domain.meetings.domain.Meeting;
+import com.example.momo.domain.meetings.enums.MeetingStatus;
+
+import lombok.Getter;
+
+@Getter
+public class MeetingResponse {
+
+	private final Long id;
+	private final Long hostUserId;
+	private final String title;
+	private final String description;
+	private final int categoryId;
+	private final int currentParticipantsCount;
+	private final int maxParticipantsCount;
+	private final LocalDateTime meetingDate;
+	private final LocalDateTime meetingEndDate;
+	private final String locationName;
+	private final Double latitude;
+	private final Double longitude;
+	private final Double minEnterScore;
+	private final int participationFee;
+	private final MeetingStatus status;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
+
+	public MeetingResponse(Meeting meeting) {
+		this.id = meeting.getId();
+		this.hostUserId = meeting.getHostUserId();
+		this.title = meeting.getTitle();
+		this.description = meeting.getDescription();
+		this.categoryId = meeting.getCategoryId();
+		this.currentParticipantsCount = meeting.getCurrentParticipantsCount();
+		this.maxParticipantsCount = meeting.getMaxParticipantsCount();
+		this.meetingDate = meeting.getMeetingDate();
+		this.meetingEndDate = meeting.getMeetingEndDate();
+		this.locationName = meeting.getLocationName();
+		this.latitude = meeting.getLatitude();
+		this.longitude = meeting.getLongitude();
+		this.minEnterScore = meeting.getMinEnterScore();
+		this.participationFee = meeting.getParticipationFee();
+		this.status = meeting.getStatus();
+		this.createdAt = meeting.getCreatedAt();
+		this.updatedAt = meeting.getUpdatedAt();
+	}
+}


### PR DESCRIPTION
### 기능 구현
- 모임 생성, 수정, 삭제
- 단건 조회, 목록 조회
- 목록 조회는 우선 동적 기능은 제외하고 제목조회만 넣었습니다( 추후 브랜치 새로 파서 queryDsl 사용하여 처리 예정)

### 주의 사항
- 예외 처리 로직 통일은 다음 브랜치에서 작성 예정입니다.
- categoryId 형식 변환 (int -> Integer Null 포함 하기 위함)
- 최대 참여자수도 null을 포함해야하는지? 현재는 필수값으로 들어가 있습니다.