### PR TITLE
fix: 언팔로우 기능 수정

### DIFF
--- a/src/main/java/com/example/momo/domain/user/application/UserService.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserService.java
@@ -31,8 +31,6 @@ public interface UserService {
 
 	void followUser(Long followerId, Long followingId);
 
-	void unfollowUser(Long followerId, Long followingId);
-
 	/**
 	 * 특정 사용자가 팔로잉하는 사용자 목록 조회 (미리 집계된 totalCount 활용)
 	 */
@@ -42,4 +40,11 @@ public interface UserService {
 	 * 특정 사용자를 팔로우하는 사용자 목록 조회 (미리 집계된 totalCount 활용)
 	 */
 	UserFollowListResponseDto getFollowers(Long userId, Pageable pageable);
+
+	/**
+	 * 팔로우 관계 삭제 (물리 삭제)
+	 * @param followerId 팔로워 ID
+	 * @param followingId 팔로잉 대상 ID
+	 */
+	void unfollowUser(Long followerId, Long followingId);
 }

--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -292,25 +292,24 @@ public class UserServiceImpl implements UserService {
 	@Override
 	@Transactional
 	public void unfollowUser(Long followerId, Long followingId) {
-		// 1. 자기 자신 언팔로우 방지 (사실상 불가능하지만 안전장치)
 		if (followerId.equals(followingId)) {
 			throw new UserException(UserErrorCode.CANNOT_FOLLOW_SELF);
 		}
 
-		// 2. 팔로워(나) 존재 확인
 		User follower = validateAndGetUser(followerId);
-
-		// 3. 팔로잉 대상 존재 확인
 		User following = validateAndGetUser(followingId);
 
-		// 4. 팔로우 관계 찾기
-		UserFollow followToRemove = follower.getFollowings().stream()
-			.filter(follow -> follow.getFollowingId().equals(followingId))
-			.findFirst()
-			.orElseThrow(() -> new UserException(UserErrorCode.NOT_FOLLOWING));
+		boolean isFollowing = follower.getFollowings().stream()
+			.anyMatch(follow -> follow.getFollowingId().equals(followingId));
 
-		// 5. 팔로우 관계 제거
-		follower.getFollowings().remove(followToRemove);
+		if (!isFollowing) {
+			throw new UserException(UserErrorCode.NOT_FOLLOWING);
+		}
+
+		int deletedCount = userRepository.deleteUserFollow(followerId, followingId);
+		if (deletedCount == 0) {
+			throw new UserException(UserErrorCode.NOT_FOLLOWING);
+		}
 
 		follower.decrementFollowingCount();     // 내 팔로잉 수 -1
 		following.decrementFollowerCount();     // 상대방 팔로워 수 -1

--- a/src/main/java/com/example/momo/domain/user/infra/UserJpaRepository.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserJpaRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -41,4 +42,8 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmailAndIsDeletedFalse(String email);
 
 	Optional<User> findByIdAndIsDeletedFalse(Long id);
+
+	@Modifying
+	@Query("DELETE FROM UserFollow uf WHERE uf.followerId = :followerId AND uf.followingId = :followingId")
+	int deleteUserFollow(@Param("followerId") Long followerId, @Param("followingId") Long followingId);
 }

--- a/src/main/java/com/example/momo/domain/user/infra/UserRepository.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserRepository.java
@@ -27,6 +27,14 @@ public interface UserRepository {
 	 */
 	Slice<User> findFollowersByUserId(Long userId, Pageable pageable);
 
+	/**
+	 * 팔로우 관계 삭제 (물리 삭제)
+	 * @param followerId 팔로워 ID
+	 * @param followingId 팔로잉 대상 ID
+	 * @return 삭제된 행 개수
+	 */
+	int deleteUserFollow(Long followerId, Long followingId);
+
 	// Auth 쪽에서 사용
 	boolean existsByEmail(String email);
 

--- a/src/main/java/com/example/momo/domain/user/infra/UserRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserRepositoryImpl.java
@@ -32,6 +32,11 @@ public class UserRepositoryImpl implements UserRepository {
 	}
 
 	@Override
+	public int deleteUserFollow(Long followerId, Long followingId) {
+		return userJpaRepository.deleteUserFollow(followerId, followingId);
+	}
+
+	@Override
 	public boolean existsByEmail(String email) {
 		return userJpaRepository.existsByEmail(email);
 	}

--- a/src/main/java/com/example/momo/domain/user/presentation/UserController.java
+++ b/src/main/java/com/example/momo/domain/user/presentation/UserController.java
@@ -1,4 +1,4 @@
-package com.example.momo.domain.user.api;
+package com.example.momo.domain.user.presentation;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto:
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
- JPA는 update 쿼리만 날리고 delete 쿼리는 날리지 않아서 레퍼지토리에 별도의 쿼리 작성해서 해결
- UserFollowRepository 이런 식으로 별도로 관리해줘도 되지만, 그러면 도메인 간 경계가 명확해지지 않는다고 생각하여 하나로 관리
- 하지만 너무 API가 더 늘어나고 비대해진다면 그 때는 별도의 레퍼지토리랑 서비스로 관리해줄 예정 (그러면 이 때는 키값만 가지고 있고, User와 동일한 라이프사이클을 가지지 않는다고 여겨야할듯)