### PR TITLE
Api Documentation Generator 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     //websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/momo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/momo/global/config/SecurityConfig.java
@@ -82,6 +82,10 @@ public class SecurityConfig {
 					"/api/v1/auth/reissue",
 					"/api/v1/categories/**"
 				).permitAll()
+				.requestMatchers(
+					"/swagger-ui/**",
+					"/v3/api-docs/**"
+				).permitAll()
 				.anyRequest().authenticated()
 			)
 			.exceptionHandling(configure -> configure

--- a/src/main/java/com/example/momo/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/momo/global/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.example.momo.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI openAPI() {
+		SecurityScheme bearerAuth = new SecurityScheme()
+			.type(SecurityScheme.Type.HTTP)
+			.scheme("bearer")
+			.bearerFormat("JWT");
+
+		SecurityRequirement securityRequirement = new SecurityRequirement()
+			.addList("BearerAuth");
+
+		return new OpenAPI()
+			.components(new Components().addSecuritySchemes("BearerAuth", bearerAuth))
+			.addSecurityItem(securityRequirement);
+	}
+}

--- a/src/main/java/com/example/momo/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/momo/global/config/SwaggerConfig.java
@@ -8,6 +8,10 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 
+/**
+ *  Swagger 주소 : http://localhost:8080/swagger-ui/index.html#/
+ */
+
 @Configuration
 public class SwaggerConfig {
 


### PR DESCRIPTION
### ⚡️ 구현 목록
- Api 문서화 툴 확인 후 범용성과 비용, 학습량을 고려하여 Swagger 도입 (간단히 Api만 확인할 용도이기 때문)
- SpringSecurity Swagger 관련 주소 permitAll 설정
---

### ⚡️ 주의 사항
- 로그인 후 accessToken만 복사 붙여 넣어서 로그인하시면 됩니다 (Bearer 미포함)
---
