### PR TITLE
ci: dev-v2 브랜치에 맞게 CI 워크플로우 브랜치 트리거 수정

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -1,10 +1,10 @@
-name: MOMO CI v1 (build only)
+name: MOMO CI v2 (build only)
 
 on:
   push:
-    branches: [dev]
+    branches: [ dev-v2 ]
   pull_request:
-    branches: [dev]
+    branches: [ dev-v2 ]
 
 jobs:
   build:


### PR DESCRIPTION
## #️⃣작업 한줄 요약 :
ci: dev-v2 브랜치에 맞게 CI 워크플로우 브랜치 트리거 수정

## 📝작업 내용> 
push 및 pull_request 이벤트 기준 브랜치를 dev → dev-v2로 변경
