### PR TITLE
Meeting WebClient 단건 조회, 알림 이벤트 발행

### DIFF
--- a/src/main/java/com/example/momo/domain/meeting/api/MeetingController.java
+++ b/src/main/java/com/example/momo/domain/meeting/api/MeetingController.java
@@ -49,9 +49,9 @@ public class MeetingController {
 	}
 
 	@GetMapping("/{meetingId}")
-	public ResponseEntity<ApiResponse<MeetingResponseDto>> searchMeeting(@PathVariable Long meetingId) {
+	public ResponseEntity<ApiResponse<MeetingResponseDto>> getMeeting(@PathVariable Long meetingId) {
 
-		MeetingResponseDto response = meetingService.searchMeeting(meetingId);
+		MeetingResponseDto response = meetingService.getMeeting(meetingId);
 		return ResponseEntity.ok(ApiResponse.success("모임 조회가 성공적으로 완료되었습니다.", response));
 	}
 
@@ -73,7 +73,7 @@ public class MeetingController {
 	}
 
 	@GetMapping
-	public ResponseEntity<ApiResponse<MeetingPagingResponseDto<MeetingResponseDto>>> searchMeetings(
+	public ResponseEntity<ApiResponse<MeetingPagingResponseDto<MeetingResponseDto>>> getMeetings(
 		@RequestParam(defaultValue = "") String title,
 		@RequestParam(required = false) MeetingStatus status,
 		@RequestParam(required = false) LocalDateTime meetingDate,

--- a/src/main/java/com/example/momo/domain/meeting/api/MeetingController.java
+++ b/src/main/java/com/example/momo/domain/meeting/api/MeetingController.java
@@ -3,7 +3,6 @@ package com.example.momo.domain.meeting.api;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.example.momo.domain.meeting.domain.dto.response.ParticipantResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -19,14 +18,15 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.momo.domain.auth.domain.dto.AuthUser;
-import com.example.momo.global.common.dto.ApiResponse;
 import com.example.momo.domain.meeting.application.MeetingService;
+import com.example.momo.domain.meeting.domain.dto.request.MeetingCreateRequestDto;
+import com.example.momo.domain.meeting.domain.dto.request.MeetingStatusUpdateRequestDto;
+import com.example.momo.domain.meeting.domain.dto.request.MeetingUpdateRequestDto;
+import com.example.momo.domain.meeting.domain.dto.response.MeetingPagingResponseDto;
+import com.example.momo.domain.meeting.domain.dto.response.MeetingResponseDto;
+import com.example.momo.domain.meeting.domain.dto.response.ParticipantResponseDto;
 import com.example.momo.domain.meeting.enums.MeetingStatus;
-import com.example.momo.domain.meeting.domain.dto.request.MeetingCreateRequest;
-import com.example.momo.domain.meeting.domain.dto.request.MeetingStatusUpdateRequest;
-import com.example.momo.domain.meeting.domain.dto.request.MeetingUpdateRequest;
-import com.example.momo.domain.meeting.domain.dto.response.MeetingPagingResponse;
-import com.example.momo.domain.meeting.domain.dto.response.MeetingResponse;
+import com.example.momo.global.common.dto.ApiResponse;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -41,38 +41,39 @@ public class MeetingController {
 	private final MeetingService meetingService;
 
 	@PostMapping
-	public ResponseEntity<ApiResponse<MeetingResponse>> createMeeting(
-		@RequestBody @Valid MeetingCreateRequest request, @AuthenticationPrincipal AuthUser authUser) {
+	public ResponseEntity<ApiResponse<MeetingResponseDto>> createMeeting(
+		@RequestBody @Valid MeetingCreateRequestDto request, @AuthenticationPrincipal AuthUser authUser) {
 
-		MeetingResponse response = meetingService.createMeeting(request, authUser.getId());
+		MeetingResponseDto response = meetingService.createMeeting(request, authUser.getId());
 		return ResponseEntity.ok(ApiResponse.success("모임 생성이 성공적으로 완료되었습니다.", response));
 	}
 
 	@GetMapping("/{meetingId}")
-	public ResponseEntity<ApiResponse<MeetingResponse>> searchMeeting(@PathVariable Long meetingId) {
+	public ResponseEntity<ApiResponse<MeetingResponseDto>> searchMeeting(@PathVariable Long meetingId) {
 
-		MeetingResponse response = meetingService.searchMeeting(meetingId);
+		MeetingResponseDto response = meetingService.searchMeeting(meetingId);
 		return ResponseEntity.ok(ApiResponse.success("모임 조회가 성공적으로 완료되었습니다.", response));
 	}
 
 	@PutMapping("/{meetingId}")
-	public ResponseEntity<ApiResponse<MeetingResponse>> updateMeeting(@PathVariable Long meetingId,
-		@RequestBody @Valid MeetingUpdateRequest request, @AuthenticationPrincipal AuthUser authUser) {
+	public ResponseEntity<ApiResponse<MeetingResponseDto>> updateMeeting(@PathVariable Long meetingId,
+		@RequestBody @Valid MeetingUpdateRequestDto request, @AuthenticationPrincipal AuthUser authUser) {
 
-		MeetingResponse response = meetingService.updateMeeting(request, meetingId, authUser.getId());
+		MeetingResponseDto response = meetingService.updateMeeting(request, meetingId, authUser.getId());
 		return ResponseEntity.ok(ApiResponse.success("모임 수정이 성공적으로 완료되었습니다.", response));
 	}
 
 	@PatchMapping("/{meetingId}")
-	public ResponseEntity<ApiResponse<MeetingResponse>> updateMeetingStatus(@PathVariable Long meetingId,
-		@RequestBody MeetingStatusUpdateRequest request, @AuthenticationPrincipal AuthUser authUser) {
+	public ResponseEntity<ApiResponse<MeetingResponseDto>> updateMeetingStatus(@PathVariable Long meetingId,
+		@RequestBody MeetingStatusUpdateRequestDto request, @AuthenticationPrincipal AuthUser authUser) {
 
-		MeetingResponse response = meetingService.updateMeetingStatus(meetingId, request.getStatus(), authUser.getId());
+		MeetingResponseDto response = meetingService.updateMeetingStatus(meetingId, request.getStatus(),
+			authUser.getId());
 		return ResponseEntity.ok(ApiResponse.success("모임 상태 변경이 성공적으로 완료되었습니다.", response));
 	}
 
 	@GetMapping
-	public ResponseEntity<ApiResponse<MeetingPagingResponse<MeetingResponse>>> searchMeetings(
+	public ResponseEntity<ApiResponse<MeetingPagingResponseDto<MeetingResponseDto>>> searchMeetings(
 		@RequestParam(defaultValue = "") String title,
 		@RequestParam(required = false) MeetingStatus status,
 		@RequestParam(required = false) LocalDateTime meetingDate,
@@ -80,7 +81,8 @@ public class MeetingController {
 		@RequestParam(defaultValue = "10") @Min(5) int size
 	) {
 
-		MeetingPagingResponse<MeetingResponse> response = meetingService.getMeetings(title, status, meetingDate, page,
+		MeetingPagingResponseDto<MeetingResponseDto> response = meetingService.getMeetings(title, status, meetingDate,
+			page,
 			size);
 		return ResponseEntity.ok(ApiResponse.success("모임 목록 조회가 성공적으로 완료되었습니다.", response));
 	}

--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingService.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingService.java
@@ -3,26 +3,27 @@ package com.example.momo.domain.meeting.application;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.example.momo.domain.meeting.enums.MeetingStatus;
+import com.example.momo.domain.meeting.domain.dto.request.MeetingCreateRequestDto;
+import com.example.momo.domain.meeting.domain.dto.request.MeetingUpdateRequestDto;
+import com.example.momo.domain.meeting.domain.dto.response.MeetingPagingResponseDto;
+import com.example.momo.domain.meeting.domain.dto.response.MeetingResponseDto;
 import com.example.momo.domain.meeting.domain.dto.response.ParticipantResponseDto;
-import com.example.momo.domain.meeting.domain.dto.request.MeetingCreateRequest;
-import com.example.momo.domain.meeting.domain.dto.request.MeetingUpdateRequest;
-import com.example.momo.domain.meeting.domain.dto.response.MeetingPagingResponse;
-import com.example.momo.domain.meeting.domain.dto.response.MeetingResponse;
+import com.example.momo.domain.meeting.enums.MeetingStatus;
 
 public interface MeetingService {
 
 	/** Meeting Service */
 
-	MeetingResponse createMeeting(MeetingCreateRequest request, Long userId);
+	MeetingResponseDto createMeeting(MeetingCreateRequestDto request, Long userId);
 
-	MeetingResponse updateMeeting(MeetingUpdateRequest request, Long meetingId, Long userId);
+	MeetingResponseDto updateMeeting(MeetingUpdateRequestDto request, Long meetingId, Long userId);
 
-	MeetingResponse searchMeeting(Long meetingId);
+	MeetingResponseDto searchMeeting(Long meetingId);
 
-	MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status, Long userId);
+	MeetingResponseDto updateMeetingStatus(Long meetingId, MeetingStatus status, Long userId);
 
-	MeetingPagingResponse<MeetingResponse> getMeetings(String title, MeetingStatus status, LocalDateTime meetingDate,
+	MeetingPagingResponseDto<MeetingResponseDto> getMeetings(String title, MeetingStatus status,
+		LocalDateTime meetingDate,
 		int page, int size);
 
 	void deleteMeeting(Long meetingId, Long userId);

--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingService.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingService.java
@@ -18,7 +18,7 @@ public interface MeetingService {
 
 	MeetingResponseDto updateMeeting(MeetingUpdateRequestDto request, Long meetingId, Long userId);
 
-	MeetingResponseDto searchMeeting(Long meetingId);
+	MeetingResponseDto getMeeting(Long meetingId);
 
 	MeetingResponseDto updateMeetingStatus(Long meetingId, MeetingStatus status, Long userId);
 

--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.momo.domain.meeting.application;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -11,6 +12,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.momo.domain.category.application.CategoryService;
+import com.example.momo.domain.category.domain.dto.CategoryResponseDto;
 import com.example.momo.domain.meeting.domain.Meeting;
 import com.example.momo.domain.meeting.domain.MeetingParticipant;
 import com.example.momo.domain.meeting.domain.MeetingRepository;
@@ -24,6 +27,7 @@ import com.example.momo.domain.meeting.exception.MeetingException;
 import com.example.momo.domain.meeting.exception.MeetingExceptionCode;
 import com.example.momo.domain.user.domain.User;
 import com.example.momo.domain.user.domain.UserRepository;
+import com.example.momo.global.infrastructure.springEvent.MeetingEvents;
 import com.example.momo.global.utils.HaversineUtils;
 import com.example.momo.global.utils.RetryUtil;
 
@@ -38,8 +42,10 @@ public class MeetingServiceImpl implements MeetingService {
 	private final MeetingReader meetingReader;
 
 	private final EntityManager em;
-
 	private final UserRepository userRepository;
+
+	private final ApplicationEventPublisher eventPublisher;
+	private final CategoryService categoryService;
 
 	@Override
 	@Transactional
@@ -47,6 +53,18 @@ public class MeetingServiceImpl implements MeetingService {
 
 		Meeting meeting = request.toMeeting(userId);
 		Meeting savedMeeting = meetingRepository.save(meeting);
+
+		// TODO CategoryId를 통한 category name 조회 (http client 요청)로 변경
+		CategoryResponseDto category = categoryService.getCategory(request.getCategoryId());
+
+		eventPublisher.publishEvent(new MeetingEvents.Create(
+			meeting.getId(),
+			request.getCategoryId(),
+			category.getCategoryName(),
+			meeting.getLatitude(),
+			meeting.getLongitude()
+		));
+
 		return new MeetingResponseDto(savedMeeting);
 	}
 
@@ -63,12 +81,18 @@ public class MeetingServiceImpl implements MeetingService {
 
 		meeting.updateMeeting(request);
 
+		eventPublisher.publishEvent(new MeetingEvents.Update(
+			meeting.getId(),
+			meeting.getTitle(),
+			meeting.getParticipants().stream().map(MeetingParticipant::getId).toList()
+		));
+
 		return new MeetingResponseDto(meeting);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
-	public MeetingResponseDto searchMeeting(Long meetingId) {
+	public MeetingResponseDto getMeeting(Long meetingId) {
 
 		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
 			new MeetingException(MeetingExceptionCode.MEETING_NOT_FOUND));
@@ -98,7 +122,7 @@ public class MeetingServiceImpl implements MeetingService {
 		Pageable pageable = PageRequest
 			.of(page - 1, size, Sort.Direction.DESC, "createdAt");
 
-		Page<Meeting> meetingPage = meetingRepository.findMeetings(title, meetingDate, status, pageable);
+		Page<Meeting> meetingPage = meetingRepository.getMeetings(title, meetingDate, status, pageable);
 		List<MeetingResponseDto> meetingResponses = meetingPage.stream()
 			.map(MeetingResponseDto::new)
 			.toList();
@@ -123,6 +147,12 @@ public class MeetingServiceImpl implements MeetingService {
 		}
 
 		meeting.delete();
+
+		eventPublisher.publishEvent(new MeetingEvents.Delete(
+			meeting.getId(),
+			meeting.getTitle(),
+			meeting.getParticipants().stream().map(MeetingParticipant::getId).toList()
+		));
 	}
 
 	/**

--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
@@ -3,31 +3,31 @@ package com.example.momo.domain.meeting.application;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.example.momo.domain.meeting.domain.MeetingParticipant;
-import com.example.momo.domain.user.domain.User;
-import com.example.momo.domain.user.domain.UserRepository;
-import com.example.momo.global.utils.HaversineUtils;
-import com.example.momo.global.utils.RetryUtil;
-import jakarta.persistence.EntityManager;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import com.example.momo.domain.meeting.domain.dto.response.ParticipantResponseDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.momo.domain.meeting.domain.Meeting;
+import com.example.momo.domain.meeting.domain.MeetingParticipant;
 import com.example.momo.domain.meeting.domain.MeetingRepository;
+import com.example.momo.domain.meeting.domain.dto.request.MeetingCreateRequestDto;
+import com.example.momo.domain.meeting.domain.dto.request.MeetingUpdateRequestDto;
+import com.example.momo.domain.meeting.domain.dto.response.MeetingPagingResponseDto;
+import com.example.momo.domain.meeting.domain.dto.response.MeetingResponseDto;
+import com.example.momo.domain.meeting.domain.dto.response.ParticipantResponseDto;
 import com.example.momo.domain.meeting.enums.MeetingStatus;
 import com.example.momo.domain.meeting.exception.MeetingException;
 import com.example.momo.domain.meeting.exception.MeetingExceptionCode;
-import com.example.momo.domain.meeting.domain.dto.request.MeetingCreateRequest;
-import com.example.momo.domain.meeting.domain.dto.request.MeetingUpdateRequest;
-import com.example.momo.domain.meeting.domain.dto.response.MeetingPagingResponse;
-import com.example.momo.domain.meeting.domain.dto.response.MeetingResponse;
+import com.example.momo.domain.user.domain.User;
+import com.example.momo.domain.user.domain.UserRepository;
+import com.example.momo.global.utils.HaversineUtils;
+import com.example.momo.global.utils.RetryUtil;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -43,16 +43,16 @@ public class MeetingServiceImpl implements MeetingService {
 
 	@Override
 	@Transactional
-	public MeetingResponse createMeeting(MeetingCreateRequest request, Long userId) {
+	public MeetingResponseDto createMeeting(MeetingCreateRequestDto request, Long userId) {
 
 		Meeting meeting = request.toMeeting(userId);
 		Meeting savedMeeting = meetingRepository.save(meeting);
-		return new MeetingResponse(savedMeeting);
+		return new MeetingResponseDto(savedMeeting);
 	}
 
 	@Override
 	@Transactional
-	public MeetingResponse updateMeeting(MeetingUpdateRequest request, Long meetingId, Long userId) {
+	public MeetingResponseDto updateMeeting(MeetingUpdateRequestDto request, Long meetingId, Long userId) {
 
 		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
 			new MeetingException(MeetingExceptionCode.MEETING_NOT_FOUND));
@@ -63,21 +63,21 @@ public class MeetingServiceImpl implements MeetingService {
 
 		meeting.updateMeeting(request);
 
-		return new MeetingResponse(meeting);
+		return new MeetingResponseDto(meeting);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
-	public MeetingResponse searchMeeting(Long meetingId) {
+	public MeetingResponseDto searchMeeting(Long meetingId) {
 
 		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
 			new MeetingException(MeetingExceptionCode.MEETING_NOT_FOUND));
-		return new MeetingResponse(meeting);
+		return new MeetingResponseDto(meeting);
 	}
 
 	@Override
 	@Transactional
-	public MeetingResponse updateMeetingStatus(Long meetingId, MeetingStatus status, Long userId) {
+	public MeetingResponseDto updateMeetingStatus(Long meetingId, MeetingStatus status, Long userId) {
 
 		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
 			new MeetingException(MeetingExceptionCode.MEETING_NOT_FOUND));
@@ -87,23 +87,23 @@ public class MeetingServiceImpl implements MeetingService {
 		}
 
 		meeting.updateStatus(status);
-		return new MeetingResponse(meeting);
+		return new MeetingResponseDto(meeting);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
-	public MeetingPagingResponse<MeetingResponse> getMeetings(String title, MeetingStatus status,
+	public MeetingPagingResponseDto<MeetingResponseDto> getMeetings(String title, MeetingStatus status,
 		LocalDateTime meetingDate, int page, int size) {
 
 		Pageable pageable = PageRequest
 			.of(page - 1, size, Sort.Direction.DESC, "createdAt");
 
 		Page<Meeting> meetingPage = meetingRepository.findMeetings(title, meetingDate, status, pageable);
-		List<MeetingResponse> meetingResponses = meetingPage.stream()
-			.map(MeetingResponse::new)
+		List<MeetingResponseDto> meetingResponses = meetingPage.stream()
+			.map(MeetingResponseDto::new)
 			.toList();
 
-		return new MeetingPagingResponse<>(
+		return new MeetingPagingResponseDto<>(
 			meetingResponses,
 			meetingPage.getTotalElements(),
 			meetingPage.getTotalPages(),
@@ -140,7 +140,7 @@ public class MeetingServiceImpl implements MeetingService {
 			.orElseThrow(() -> new RuntimeException("user not found"));
 
 		// 이미 참가했으면 예외처리
-		if(meetingRepository.existsByMeetingIdAndUserId(meetingId, userId)) {
+		if (meetingRepository.existsByMeetingIdAndUserId(meetingId, userId)) {
 			throw new MeetingException(MeetingExceptionCode.ALREADY_PARTICIPATED);
 		}
 
@@ -148,7 +148,7 @@ public class MeetingServiceImpl implements MeetingService {
 		isMeetingOpen(meeting);
 
 		// 유저 자격 확인
-		if(user.getScore() < meeting.getMinEnterScore()) {
+		if (user.getScore() < meeting.getMinEnterScore()) {
 			throw new MeetingException(MeetingExceptionCode.INSUFFICIENT_SCORE);
 		}
 
@@ -169,7 +169,7 @@ public class MeetingServiceImpl implements MeetingService {
 	@Override
 	@Transactional(readOnly = true)
 	public List<Long> getParticipants(Long meetingId) {
-		if(!meetingRepository.existsById(meetingId)) {
+		if (!meetingRepository.existsById(meetingId)) {
 			throw new MeetingException(MeetingExceptionCode.MEETING_NOT_FOUND);
 		}
 
@@ -205,7 +205,7 @@ public class MeetingServiceImpl implements MeetingService {
 		Double destLng = meeting.getLongitude();
 
 		// 위치가 목적지 근처인지 확인
-		if(!HaversineUtils.isInDistance(destLat, destLng, lat, lng)) {
+		if (!HaversineUtils.isInDistance(destLat, destLng, lat, lng)) {
 			throw new MeetingException(MeetingExceptionCode.FAR_FROM_MEETING);
 		}
 
@@ -220,17 +220,17 @@ public class MeetingServiceImpl implements MeetingService {
 	private void isMeetingOpen(Meeting meeting) {
 
 		// 시작 시간 넘김
-		if(LocalDateTime.now().isAfter(meeting.getMeetingDate())) {
+		if (LocalDateTime.now().isAfter(meeting.getMeetingDate())) {
 			throw new MeetingException(MeetingExceptionCode.ALREADY_STARTED_MEETING);
 		}
 
 		// 모임 상태 FINISHED
-		if(meeting.getStatus() == MeetingStatus.FINISHED) {
+		if (meeting.getStatus() == MeetingStatus.FINISHED) {
 			throw new MeetingException(MeetingExceptionCode.ALREADY_FINISHED_MEETING);
 		}
 
 		// 삭제된 모임
-		if(meeting.getIsDeleted()) {
+		if (meeting.getIsDeleted()) {
 			throw new MeetingException(MeetingExceptionCode.DELETED_MEETING);
 		}
 	}
@@ -239,7 +239,7 @@ public class MeetingServiceImpl implements MeetingService {
 	@Transactional
 	public ParticipantResponseDto addParticipant(Meeting meeting, User user) {
 
-		if(meeting.getCurrentParticipantsCount() >= meeting.getMaxParticipantsCount()) {
+		if (meeting.getCurrentParticipantsCount() >= meeting.getMaxParticipantsCount()) {
 			throw new MeetingException(MeetingExceptionCode.MEETING_IS_FULL);
 		}
 
@@ -256,11 +256,12 @@ public class MeetingServiceImpl implements MeetingService {
 	@Transactional
 	public ParticipantResponseDto removeParticipant(Meeting meeting, User user) {
 
-		if(meeting.getCurrentParticipantsCount() <= 0) {
+		if (meeting.getCurrentParticipantsCount() <= 0) {
 			throw new MeetingException(MeetingExceptionCode.INVALID_PARTICIPANT_COUNT);
 		}
 
-		MeetingParticipant participant = meetingReader.getParticipantByMeetingIdAndUserId(meeting.getId(), user.getId());
+		MeetingParticipant participant = meetingReader.getParticipantByMeetingIdAndUserId(meeting.getId(),
+			user.getId());
 
 		// 인원 계산, 참가자 삭제
 		meeting.removeMeetingParticipant();

--- a/src/main/java/com/example/momo/domain/meeting/domain/Meeting.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/Meeting.java
@@ -4,11 +4,22 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.example.momo.global.common.entity.BaseEntity;
+import com.example.momo.domain.meeting.domain.dto.request.MeetingUpdateRequestDto;
 import com.example.momo.domain.meeting.enums.MeetingStatus;
-import com.example.momo.domain.meeting.domain.dto.request.MeetingUpdateRequest;
+import com.example.momo.global.common.entity.BaseEntity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -80,7 +91,7 @@ public class Meeting extends BaseEntity {
 	@Version
 	private Long version;
 
-	public void updateMeeting(MeetingUpdateRequest request) {
+	public void updateMeeting(MeetingUpdateRequestDto request) {
 		this.title = request.getTitle();
 		this.description = request.getDescription();
 		this.categoryId = request.getCategoryId();

--- a/src/main/java/com/example/momo/domain/meeting/domain/MeetingRepository.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/MeetingRepository.java
@@ -17,7 +17,7 @@ public interface MeetingRepository {
 
 	Meeting save(Meeting meeting);
 
-	Page<Meeting> findMeetings(String title, LocalDateTime meetingDate, MeetingStatus status,
+	Page<Meeting> getMeetings(String title, LocalDateTime meetingDate, MeetingStatus status,
 		Pageable pageable);
 
 	boolean existsById(Long id);

--- a/src/main/java/com/example/momo/domain/meeting/domain/dto/request/MeetingCreateRequestDto.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/dto/request/MeetingCreateRequestDto.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
-public class MeetingCreateRequest {
+public class MeetingCreateRequestDto {
 
 	@NotBlank
 	private String title;

--- a/src/main/java/com/example/momo/domain/meeting/domain/dto/request/MeetingStatusUpdateRequestDto.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/dto/request/MeetingStatusUpdateRequestDto.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
-public class MeetingStatusUpdateRequest {
+public class MeetingStatusUpdateRequestDto {
 
 	@NotBlank
 	private MeetingStatus status;

--- a/src/main/java/com/example/momo/domain/meeting/domain/dto/request/MeetingUpdateRequestDto.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/dto/request/MeetingUpdateRequestDto.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
-public class MeetingUpdateRequest {
+public class MeetingUpdateRequestDto {
 
 	@NotBlank
 	private String title;

--- a/src/main/java/com/example/momo/domain/meeting/domain/dto/response/MeetingPagingResponseDto.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/dto/response/MeetingPagingResponseDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class MeetingPagingResponse<T> {
+public class MeetingPagingResponseDto<T> {
 
 	private List<T> data;
 	private Long total;

--- a/src/main/java/com/example/momo/domain/meeting/domain/dto/response/MeetingResponseDto.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/dto/response/MeetingResponseDto.java
@@ -8,7 +8,7 @@ import com.example.momo.domain.meeting.enums.MeetingStatus;
 import lombok.Getter;
 
 @Getter
-public class MeetingResponse {
+public class MeetingResponseDto {
 
 	private final Long id;
 	private final Long hostUserId;
@@ -28,7 +28,7 @@ public class MeetingResponse {
 	private final LocalDateTime createdAt;
 	private final LocalDateTime updatedAt;
 
-	public MeetingResponse(Meeting meeting) {
+	public MeetingResponseDto(Meeting meeting) {
 		this.id = meeting.getId();
 		this.hostUserId = meeting.getHostUserId();
 		this.title = meeting.getTitle();

--- a/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingRepositoryImpl.java
@@ -4,15 +4,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import com.example.momo.domain.meeting.domain.MeetingParticipant;
-import com.example.momo.domain.meeting.infra.participant.MeetingParticipantRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.example.momo.domain.meeting.domain.Meeting;
+import com.example.momo.domain.meeting.domain.MeetingParticipant;
 import com.example.momo.domain.meeting.domain.MeetingRepository;
 import com.example.momo.domain.meeting.enums.MeetingStatus;
+import com.example.momo.domain.meeting.infra.participant.MeetingParticipantRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,7 +37,7 @@ public class MeetingRepositoryImpl implements MeetingRepository {
 	}
 
 	@Override
-	public Page<Meeting> findMeetings(String title, LocalDateTime meetingDate, MeetingStatus status,
+	public Page<Meeting> getMeetings(String title, LocalDateTime meetingDate, MeetingStatus status,
 		Pageable pageable) {
 
 		return meetingQueryRepository.findMeetings(title, meetingDate, status, pageable);

--- a/src/main/java/com/example/momo/global/infrastructure/client/meeting/MeetingClient.java
+++ b/src/main/java/com/example/momo/global/infrastructure/client/meeting/MeetingClient.java
@@ -1,4 +1,54 @@
 package com.example.momo.global.infrastructure.client.meeting;
 
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import com.example.momo.global.common.dto.ApiResponse;
+import com.example.momo.global.infrastructure.client.meeting.dto.MeetingClientResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
 public class MeetingClient {
+
+	private static final String MEETING_SERVICE_BASE_URL = "/api/v1/meetings";
+	private final WebClient webClient;
+
+	/**
+	 * 단일 모임 정보 조회
+	 *
+	 * @param meetingId 조회 모임 ID
+	 * @return 모임 정보 DTO
+	 */
+	public MeetingClientResponseDto getMeeting(Long meetingId) {
+
+		try {
+			ApiResponse<MeetingClientResponseDto> response = webClient
+				.get()
+				.uri(MEETING_SERVICE_BASE_URL + "/{meetingId}", meetingId)
+				.retrieve()
+				.bodyToMono(new ParameterizedTypeReference<ApiResponse<MeetingClientResponseDto>>() {
+				})
+				.block();
+
+			if (response == null || !response.isSuccess()) {
+				return null;
+			}
+
+			return response.getData();
+		} catch (WebClientResponseException e) {
+
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+				return null;
+			}
+
+			throw new MeetingClientException("모임 단건 조회 중 오류가 발생했습니다. " + e.getMessage());
+		} catch (Exception e) {
+			throw new MeetingClientException("모임 단건 조회 중 오류가 발생했습니다. " + e.getMessage());
+		}
+	}
 }

--- a/src/main/java/com/example/momo/global/infrastructure/client/meeting/dto/MeetingClientResponseDto.java
+++ b/src/main/java/com/example/momo/global/infrastructure/client/meeting/dto/MeetingClientResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.momo.global.infrastructure.client.meeting.dto;
+
+import java.time.LocalDateTime;
+
+import com.example.momo.domain.meeting.enums.MeetingStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MeetingClientResponseDto {
+
+	private final Long id;
+	private final Long hostUserId;
+	private final String title;
+	private final String description;
+	private final Integer categoryId;
+	private final int currentParticipantsCount;
+	private final int maxParticipantsCount;
+	private final LocalDateTime meetingDate;
+	private final LocalDateTime meetingEndDate;
+	private final String locationName;
+	private final Double latitude;
+	private final Double longitude;
+	private final Double minEnterScore;
+	private final int participationFee;
+	private final MeetingStatus status;
+}


### PR DESCRIPTION
### ⚡️구현 목록
- 메서드명 룰에 맞춰 수정( -> get+@)
- 알림 이벤트 발행 (생성 수정 삭제)
- webClient 단일 조회 구성

### ⚡️주의 사항
- category 조회 로직은 webClient 요청으로 바꾸어 수정하겠습니다.