### PR TITLE
Feature/user v2

### DIFF
--- a/src/main/java/com/example/momo/domain/user/api/UserController.java
+++ b/src/main/java/com/example/momo/domain/user/api/UserController.java
@@ -87,6 +87,18 @@ public class UserController {
 		return ResponseEntity.ok(ApiResponse.success("내 정보를 조회했습니다.", response));
 	}
 
+	// 이메일로 사용자 조회
+	@GetMapping("/by-email")
+	public ResponseEntity<ApiResponse<UserResponseDto>> getUserByEmail(
+		@RequestParam String email
+	) {
+		UserResponseDto response = userService.getUserByEmail(email);
+		if (response == null) {
+			return ResponseEntity.ok(ApiResponse.success("해당 이메일의 사용자가 존재하지 않습니다.", null));
+		}
+		return ResponseEntity.ok(ApiResponse.success("이메일로 사용자 정보를 조회했습니다.", response));
+	}
+
 	// 사용자 필터링 조회 (카테고리, 위도, 경도)
 	@GetMapping("/filter")
 	public ResponseEntity<ApiResponse<List<UserListResponseDto>>> getUsersByLocationAndCategory(

--- a/src/main/java/com/example/momo/domain/user/application/UserService.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserService.java
@@ -34,6 +34,14 @@ public interface UserService {
 	 */
 	List<Long> getExistingUserIds(List<Long> userIds);
 
+	/**
+	 * 이메일로 사용자 정보 조회
+	 *
+	 * @param email 조회할 사용자 이메일
+	 * @return 사용자 정보 DTO (존재하지 않으면 null)
+	 */
+	UserResponseDto getUserByEmail(String email);
+
 	UserResponseDto getUserById(Long userId);
 
 	UserResponseDto getMyProfile(Long CurrentUserId);

--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -84,6 +84,14 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	@Transactional(readOnly = true)
+	public UserResponseDto getUserByEmail(String email) {
+		return userRepository.findByEmailAndIsDeletedFalse(email)
+			.map(UserResponseDto::new)
+			.orElse(null);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
 	public List<UserListResponseDto> getUsersByLocationAndCategory(
 		List<Integer> categoryIds,
 		Double latitude,
@@ -377,8 +385,8 @@ public class UserServiceImpl implements UserService {
 			throw new UserException(UserErrorCode.NOT_FOLLOWING);
 		}
 
-		follower.decrementFollowingCount();     // 내 팔로잉 수 -1
-		following.decrementFollowerCount();     // 상대방 팔로워 수 -1
+		follower.decrementFollowingCount();
+		following.decrementFollowerCount();
 	}
 
 	@Override

--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.momo.domain.user.application;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -9,9 +10,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.example.momo.domain.category.application.CategoryService;
-import com.example.momo.domain.category.domain.dto.CategoryResponseDto;
-import com.example.momo.domain.category.exception.CategoryException;
 import com.example.momo.domain.meeting.infra.participant.MeetingParticipantJpaRepository;
 import com.example.momo.domain.user.domain.User;
 import com.example.momo.domain.user.domain.UserFollow;
@@ -28,6 +26,10 @@ import com.example.momo.domain.user.domain.dto.UserRatingCreateRequestDto;
 import com.example.momo.domain.user.domain.dto.UserResponseDto;
 import com.example.momo.domain.user.exception.UserErrorCode;
 import com.example.momo.domain.user.exception.UserException;
+import com.example.momo.global.infrastructure.client.category.CategoryClient;
+import com.example.momo.global.infrastructure.client.category.dto.CategoryClientResponseDto;
+import com.example.momo.global.infrastructure.client.meeting.MeetingClient;
+import com.example.momo.global.infrastructure.client.meeting.dto.ParticipantClientResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,8 +38,9 @@ import lombok.RequiredArgsConstructor;
 public class UserServiceImpl implements UserService {
 
 	private final UserRepository userRepository;
-	private final CategoryService categoryService;
+	private final CategoryClient categoryClient;
 	private final BCryptPasswordEncoder passwordEncoder;
+	private final MeetingClient meetingClient;
 	private final MeetingParticipantJpaRepository meetingParticipantRepository;
 
 	// === 사용자 정보 조회 ===
@@ -106,19 +109,24 @@ public class UserServiceImpl implements UserService {
 	public User updateUserCategories(Long userId, List<Integer> categoryIds) {
 		User user = validateAndGetUser(userId);
 
-		try {
-			List<CategoryResponseDto> categories = categoryService.getCategories(categoryIds);
+		List<CategoryClientResponseDto> allCategories = categoryClient.getCategories();
 
-			if (categories.size() != categoryIds.size()) {
-				throw new UserException(UserErrorCode.INVALID_CATEGORY_IDS);
-			}
-
-			user.updateCategories(categoryIds);
-			return user;
-
-		} catch (CategoryException e) {
+		if (allCategories == null || allCategories.isEmpty()) {
 			throw new UserException(UserErrorCode.INVALID_CATEGORY_IDS);
 		}
+
+		List<Integer> validCategoryIds = allCategories.stream()
+			.map(CategoryClientResponseDto::getId)
+			.toList();
+
+		boolean allValid = new HashSet<>(validCategoryIds).containsAll(categoryIds);
+
+		if (!allValid) {
+			throw new UserException(UserErrorCode.INVALID_CATEGORY_IDS);
+		}
+
+		user.updateCategories(categoryIds);
+		return user;
 	}
 
 	@Override
@@ -168,15 +176,14 @@ public class UserServiceImpl implements UserService {
 		}
 
 		// 2. 평가자 존재 확인
-		User reviewer = validateAndGetUser(reviewerId);
+		validateAndGetUser(reviewerId);
 
 		// 3. 평가 대상자 존재 확인
 		User targetUser = userRepository.findByIdAndIsDeletedFalse(targetUserId)
 			.orElseThrow(() -> new UserException(UserErrorCode.TARGET_USER_NOT_FOUND));
 
 		// 4. 모임 존재 확인
-		meetingParticipantRepository.findById(request.meetingId())
-			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 모임입니다."));
+		validateSameMeetingParticipants(reviewerId, targetUserId, request.meetingId());
 
 		// 5. 같은 모임 참가 여부 확인
 		validateSameMeetingParticipants(reviewerId, targetUserId, request.meetingId());
@@ -206,11 +213,18 @@ public class UserServiceImpl implements UserService {
 	}
 
 	private void validateSameMeetingParticipants(Long reviewerId, Long targetUserId, Long meetingId) {
-		// 평가자가 해당 모임에 참가했는지 확인
-		boolean reviewerParticipated = meetingParticipantRepository.existsByMeetingIdAndUserId(meetingId, reviewerId);
+		List<ParticipantClientResponseDto> participants = meetingClient.getParticipants(meetingId);
 
-		// 평가 대상자가 해당 모임에 참가했는지 확인
-		boolean targetParticipated = meetingParticipantRepository.existsByMeetingIdAndUserId(meetingId, targetUserId);
+		if (participants == null || participants.isEmpty()) {
+			throw new UserException(UserErrorCode.NOT_SAME_MEETING_PARTICIPANTS);
+		}
+
+		List<Long> participantUserIds = participants.stream()
+			.map(ParticipantClientResponseDto::getUserId)
+			.toList();
+
+		boolean reviewerParticipated = participantUserIds.contains(reviewerId);
+		boolean targetParticipated = participantUserIds.contains(targetUserId);
 
 		if (!reviewerParticipated || !targetParticipated) {
 			throw new UserException(UserErrorCode.NOT_SAME_MEETING_PARTICIPANTS);

--- a/src/main/java/com/example/momo/global/infrastructure/client/user/UserClient.java
+++ b/src/main/java/com/example/momo/global/infrastructure/client/user/UserClient.java
@@ -105,6 +105,41 @@ public class UserClient {
 	}
 
 	/**
+	 * 이메일로 사용자 정보 조회
+	 */
+	public UserClientResponseDto getUserByEmail(String email) {
+		if (email == null || email.trim().isEmpty()) {
+			log.warn("이메일이 비어있습니다.");
+			return null;
+		}
+
+		try {
+			ApiResponse<UserClientResponseDto> response = webClient
+				.get()
+				.uri(uriBuilder -> uriBuilder
+					.path(USER_SERVICE_BASE_URL + "/by-email")
+					.queryParam("email", email)
+					.build())
+				.retrieve()
+				.bodyToMono(new ParameterizedTypeReference<ApiResponse<UserClientResponseDto>>() {
+				})
+				.timeout(REQUEST_TIMEOUT)
+				.block();
+
+			if (response != null && response.isSuccess() && response.getData() != null) {
+				log.debug("이메일로 사용자 조회 성공: email={}", email);
+				return response.getData();
+			} else {
+				log.debug("해당 이메일의 사용자가 존재하지 않습니다: email={}", email);
+				return null;
+			}
+		} catch (Exception e) {
+			log.error("이메일로 사용자 조회 실패: email={}, error={}", email, e.getMessage());
+			return null;
+		}
+	}
+
+	/**
 	 * 카테고리와 위치 조건으로 사용자 검색
 	 */
 	public List<UserClientResponseDto> getUsersByLocationAndCategory(


### PR DESCRIPTION
**구현 내용**
1. CategoryClient 참조해서 서비스 로직 변경 (테스트 성공)
2. 이메일에 따른 유저 정보가 있는지 확인하는 API 생성 (테스트 성공)


**이후에 할 내용**
1. 회원가입과 회원탈퇴 로직을 User 도메인으로 책임 변경
2. UserSocial 테이블에서 테이블 연관관계를 끊고, 이메일 사용자 조회 API를 통해 검증하는 식으로 변경하여 Auth와 User 도메인간의 책임경계가 어느정도 명확해질 예정

**수정해야할 부분**
1. 모임 참가 로직이 지금 되게 복잡하게 구현되어있는데, 루트 엔티티인 Meeting이 참가에 따른 카운트 변경 메서드가 존재하는데, 이를 바로 createParticipant 메서드 내에서 해줘도 될거같습니다. 이는 저녁 회고시간에 얘기해보겠습니다.
2. 그리고 현재 호스트는 참가목록에 뜨지 않는거같은데, 이렇게 되면 사용자 평가시에 호스트에 대한 평가와 호스트가 자신의 모임에 참석한 유저들에 대해 평가가 이루어지지 않습니다.
3. 그리고 현재 유저 평가에 대한 책임이 완전히 유저쪽으로 몰려있는데, 이 부분에 대해서도 생각해봐야할거같습니다. 지금 방식에서 count와 status에 대한 API를 만들어서 제가 그걸 받아주는 식으로 해도되고, 아니면 그냥 제쪽에서 조회만해서 카운트처리를 평가 서비스에서 해줘도됩니다. 아니면 이제 User_Meeting_History같은 별도의 테이블을 생성하여 유저쪽에서 관리해줘도됩니다.
 하지만, 이렇게 되면 현재 User도메인을 보시면 아시겠지만, 이미 책임이 너무 많기에 이는 고려해봐야할거같습니다. 다르게 생각해보면 이 유저 평가에 대한건 미팅쪽에서 처리를 해줘도됩니다. 이런 식으로 하고싶다! 이런 건 아니고, 현재 상황에서 저 유저 평가에 대한걸 어떤 도메인에서 처리해주고, 어떤 식으로 데이터를 가져오고, 어떤 식으로 테이블을 관리해줄지 다시 한 번 생각해봐야할거같습니다. 
  '사용자 평가' 라는 측면에서 봤을때는 유저쪽의 책임이 강한거같지만, 내부 비즈니스 로직을 보면 사실 미팅쪽에서 해줄 수 있는게 대부분입니다. 또한 현재 유저 도메인의 책임이 너무나도 많습니다. 그래서 이 부분에 대해서 아이디어 있으시면 공유 부탁드립니다. 
  
<img width="1053" height="465" alt="image" src="https://github.com/user-attachments/assets/c32fae6a-34d3-4637-9dcd-28baea2d6ded" />