### PR TITLE
WebClient 내부 호출 로직 수정 (버그 수정)

### DIFF
--- a/src/main/java/com/example/momo/global/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/example/momo/global/config/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package com.example.momo.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+	@Bean
+	public BCryptPasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/src/main/java/com/example/momo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/momo/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -40,6 +41,9 @@ public class SecurityConfig {
 	private final OAuth2UserService oAuth2UserService;
 	private final OAuth2SuccessHandler oAuth2SuccessHandler;
 	private final OAuth2FailureHandler oAuth2FailureHandler;
+	private final BCryptPasswordEncoder passwordEncoder;
+	@Value("${webclient.internal.secret-key}")
+	private String webSecretKey;
 
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
@@ -73,7 +77,8 @@ public class SecurityConfig {
 					.userService(oAuth2UserService))
 				.successHandler(oAuth2SuccessHandler)
 				.failureHandler(oAuth2FailureHandler))
-			.addFilterAt(new JwtFilter(jwtTokenProvider, objectMapper), UsernamePasswordAuthenticationFilter.class)
+			.addFilterAt(new JwtFilter(jwtTokenProvider, objectMapper, passwordEncoder, webSecretKey),
+				UsernamePasswordAuthenticationFilter.class)
 			.authorizeHttpRequests(auth -> auth
 				// 인증이 필요없는 공개 엔드포인트
 				.requestMatchers(HttpMethod.POST, "/api/v2/categories").hasRole("ADMIN")
@@ -96,10 +101,5 @@ public class SecurityConfig {
 				.accessDeniedHandler(jwtAccessDeniedHandler)
 			)
 			.build();
-	}
-
-	@Bean
-	public BCryptPasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder();
 	}
 }

--- a/src/main/java/com/example/momo/global/config/WebClientConfig.java
+++ b/src/main/java/com/example/momo/global/config/WebClientConfig.java
@@ -3,20 +3,17 @@ package com.example.momo.global.config;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.reactive.function.client.ClientRequest;
-import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
-import reactor.core.publisher.Mono;
+import lombok.RequiredArgsConstructor;
 import reactor.netty.http.client.HttpClient;
 
 /**
@@ -24,7 +21,12 @@ import reactor.netty.http.client.HttpClient;
  * 도메인간 통신을 위한 WebClient 빈을 생성
  */
 @Configuration
+@RequiredArgsConstructor
 public class WebClientConfig {
+
+	private final BCryptPasswordEncoder passwordEncoder;
+	@Value("${webclient.internal.secret-key}")
+	private String webSecretKey;
 
 	@Bean
 	public WebClient webClient() {
@@ -39,24 +41,7 @@ public class WebClientConfig {
 		return WebClient.builder()
 			.baseUrl("http://localhost:8080") // 기본 URL 설정
 			.clientConnector(new ReactorClientHttpConnector(httpClient))
-			.filter(authorizationHeaderFilter())
+			.defaultHeader("WebclientInternal", passwordEncoder.encode(webSecretKey))
 			.build();
-	}
-
-	private ExchangeFilterFunction authorizationHeaderFilter() {
-		return ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
-			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-			if(authentication != null && authentication.isAuthenticated()) {
-				Object credentials = authentication.getCredentials();
-				if(credentials instanceof String token) {
-					ClientRequest newRequest = ClientRequest.from(clientRequest)
-						.headers(headers -> headers.setBearerAuth(token))
-						.build();
-					return Mono.just(newRequest);
-				}
-			}
-			return Mono.just(clientRequest);
-		});
 	}
 }

--- a/src/main/java/com/example/momo/global/security/filter/JwtFilter.java
+++ b/src/main/java/com/example/momo/global/security/filter/JwtFilter.java
@@ -11,6 +11,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -34,6 +35,8 @@ public class JwtFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final ObjectMapper objectMapper;
+	private final BCryptPasswordEncoder passwordEncoder;
+	private final String webSecretKey;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -44,6 +47,21 @@ public class JwtFilter extends OncePerRequestFilter {
 
 		accessToken = accessToken == null ? request.getHeader(HttpHeaders.AUTHORIZATION) : accessToken;
 
+		// test
+		String testKey = request.getHeader("WebclientInternal");
+		if (passwordEncoder.matches(webSecretKey, testKey)) {
+			log.info("내부 webClient 호출 성공");
+			// webClient 용 내부 인증 객체 생성
+			Authentication webclientAuth = new UsernamePasswordAuthenticationToken(
+				"webclient-internal",
+				null,
+				List.of(new SimpleGrantedAuthority("ROLE_WEBCLIENT"))
+			);
+			SecurityContextHolder.getContext().setAuthentication(webclientAuth);
+
+			filterChain.doFilter(request, response);
+			return;
+		}
 		// Authorization 해더 값이 없으면 다음 filter로 넘김
 		// accessToken의 접두사가 "Bearer " 도 아니고 "Bearer_"도 아니면 Access 토큰이 없는 것으로 간주
 		if (!StringUtils.hasText(accessToken) || !accessToken.startsWith(JwtTokenProvider.tokenPrefix)) {

--- a/src/main/java/com/example/momo/global/security/filter/JwtFilter.java
+++ b/src/main/java/com/example/momo/global/security/filter/JwtFilter.java
@@ -86,7 +86,7 @@ public class JwtFilter extends OncePerRequestFilter {
 			// 스프링 시큐리티 인증 토큰 생성
 			Authentication authToken = new UsernamePasswordAuthenticationToken(
 				authUser,
-				accessToken,
+				"",
 				List.of(new SimpleGrantedAuthority("ROLE_" + role))
 			);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,7 @@ toss:
     secret-key: ${TOSS_SECRET_KEY}
     client-key: ${TOSS_CLIENT_KEY}
     base-url: ${TOSS_BASE_URL}
+
+webclient:
+  internal:
+    secret-key: ${WEBCLIENT_SECRET_KEY}


### PR DESCRIPTION
### ⚡️ 구현 목록
- SpringContainer에서 JwtFilter 관리하지 않기에 생성자 주입
- passwordEncoder 순환참조 문제로 인한 분리
- webClient 사용 시 `webClientInternal ` 이라는 헤더를 통해 인증 우회

### ⚡️ 주의 사항
```
WEBCLIENT_SECRET_KEY = webclientkey
```
- 위와 같이 특정 raw 값을 환경변수에 추가해주시면 됩니다.
- webClient를 내부에서만 사용하기 때문에 큰 필요성은 없다고 판단했지만 우선적으로 raw값을 그대로 넣기보다는 암호화해서 사용했습니다.
