### PR TITLE
Meeting 복합 인덱스 적용 및 모임 조회 시 category_id 필터 추가

### DIFF
--- a/src/main/java/com/example/momo/domain/meeting/api/MeetingController.java
+++ b/src/main/java/com/example/momo/domain/meeting/api/MeetingController.java
@@ -3,6 +3,7 @@ package com.example.momo.domain.meeting.api;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -76,12 +77,14 @@ public class MeetingController {
 	public ResponseEntity<ApiResponse<MeetingPagingResponseDto<MeetingResponseDto>>> getMeetings(
 		@RequestParam(defaultValue = "") String title,
 		@RequestParam(required = false) MeetingStatus status,
-		@RequestParam(required = false) LocalDateTime meetingDate,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime meetingDate,
+		@RequestParam(required = false) Integer categoryId,
 		@RequestParam(defaultValue = "1") @Min(1) int page,
 		@RequestParam(defaultValue = "10") @Min(5) int size
 	) {
 
 		MeetingPagingResponseDto<MeetingResponseDto> response = meetingService.getMeetings(title, status, meetingDate,
+			categoryId,
 			page,
 			size);
 		return ResponseEntity.ok(ApiResponse.success("모임 목록 조회가 성공적으로 완료되었습니다.", response));

--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingService.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingService.java
@@ -23,7 +23,7 @@ public interface MeetingService {
 	MeetingResponseDto updateMeetingStatus(Long meetingId, MeetingStatus status, Long userId);
 
 	MeetingPagingResponseDto<MeetingResponseDto> getMeetings(String title, MeetingStatus status,
-		LocalDateTime meetingDate,
+		LocalDateTime meetingDate, Integer categoryId,
 		int page, int size);
 
 	void deleteMeeting(Long meetingId, Long userId);

--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
@@ -120,12 +120,12 @@ public class MeetingServiceImpl implements MeetingService {
 	@Override
 	@Transactional(readOnly = true)
 	public MeetingPagingResponseDto<MeetingResponseDto> getMeetings(String title, MeetingStatus status,
-		LocalDateTime meetingDate, int page, int size) {
+		LocalDateTime meetingDate, Integer categoryId, int page, int size) {
 
 		Pageable pageable = PageRequest
 			.of(page - 1, size, Sort.Direction.DESC, "createdAt");
 
-		Page<Meeting> meetingPage = meetingRepository.getMeetings(title, meetingDate, status, pageable);
+		Page<Meeting> meetingPage = meetingRepository.getMeetings(title, meetingDate, status, categoryId, pageable);
 		List<MeetingResponseDto> meetingResponses = meetingPage.stream()
 			.map(MeetingResponseDto::new)
 			.toList();

--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
@@ -12,8 +12,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.example.momo.domain.category.application.CategoryService;
-import com.example.momo.domain.category.domain.dto.CategoryResponseDto;
 import com.example.momo.domain.meeting.domain.Meeting;
 import com.example.momo.domain.meeting.domain.MeetingParticipant;
 import com.example.momo.domain.meeting.domain.MeetingRepository;
@@ -29,6 +27,8 @@ import com.example.momo.domain.payment.application.PaymentService;
 import com.example.momo.domain.payment.domain.dto.CardPaymentTestRequest;
 import com.example.momo.domain.payment.domain.dto.RefundRequest;
 import com.example.momo.domain.user.domain.User;
+import com.example.momo.global.infrastructure.client.category.CategoryClient;
+import com.example.momo.global.infrastructure.client.category.dto.CategoryClientResponseDto;
 import com.example.momo.global.infrastructure.client.user.UserClient;
 import com.example.momo.global.infrastructure.client.user.dto.UserClientResponseDto;
 import com.example.momo.global.infrastructure.springEvent.MeetingEvents;
@@ -48,7 +48,7 @@ public class MeetingServiceImpl implements MeetingService {
 	private final EntityManager em;
 	private final UserClient userClient;
 	private final PaymentService paymentService;
-	private final CategoryService categoryService;
+	private final CategoryClient categoryClient;
 
 	@Override
 	@Transactional
@@ -57,13 +57,12 @@ public class MeetingServiceImpl implements MeetingService {
 		Meeting meeting = request.toMeeting(userId);
 		Meeting savedMeeting = meetingRepository.save(meeting);
 
-		// TODO CategoryId를 통한 category name 조회 (http client 요청)로 변경
-		CategoryResponseDto category = categoryService.getCategory(request.getCategoryId());
+		CategoryClientResponseDto category = categoryClient.getCategory(request.getCategoryId());
 
 		eventPublisher.publishEvent(new MeetingEvents.Create(
 			meeting.getId(),
 			request.getCategoryId(),
-			category.getCategoryName(),
+			category.getName(),
 			meeting.getLatitude(),
 			meeting.getLongitude()
 		));

--- a/src/main/java/com/example/momo/domain/meeting/domain/Meeting.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/Meeting.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -26,7 +27,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "meetings")
+@Table(name = "meetings", indexes = {
+	@Index(name = "idx_meeting_deleted_category_status_date", columnList = "is_deleted, category_id, status, meeting_date")
+})
 @Getter
 @Entity
 @Builder

--- a/src/main/java/com/example/momo/domain/meeting/domain/MeetingRepository.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/MeetingRepository.java
@@ -17,7 +17,7 @@ public interface MeetingRepository {
 
 	Meeting save(Meeting meeting);
 
-	Page<Meeting> getMeetings(String title, LocalDateTime meetingDate, MeetingStatus status,
+	Page<Meeting> getMeetings(String title, LocalDateTime meetingDate, MeetingStatus status, Integer categoryId,
 		Pageable pageable);
 
 	boolean existsById(Long id);

--- a/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingQueryRepository.java
+++ b/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingQueryRepository.java
@@ -9,6 +9,7 @@ import com.example.momo.domain.meeting.domain.Meeting;
 import com.example.momo.domain.meeting.enums.MeetingStatus;
 
 public interface MeetingQueryRepository {
-	
-	Page<Meeting> findMeetings(String title, LocalDateTime meetingDate, MeetingStatus status, Pageable pageable);
+
+	Page<Meeting> findMeetings(String title, LocalDateTime meetingDate, MeetingStatus status, Integer categoryId,
+		Pageable pageable);
 }

--- a/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingQueryRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingQueryRepositoryImpl.java
@@ -26,7 +26,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepository {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Page<Meeting> findMeetings(String title, LocalDateTime meetingDate, MeetingStatus status,
+	public Page<Meeting> findMeetings(String title, LocalDateTime meetingDate, MeetingStatus status, Integer categoryId,
 		Pageable pageable) {
 
 		BooleanBuilder builder = new BooleanBuilder();
@@ -45,6 +45,10 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepository {
 
 		if (status != null) {
 			builder.and(meeting.status.eq(status));
+		}
+
+		if (categoryId != null) {
+			builder.and(meeting.categoryId.eq(categoryId));
 		}
 
 		builder.and(meeting.isDeleted.eq(false));

--- a/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingRepositoryImpl.java
@@ -37,10 +37,10 @@ public class MeetingRepositoryImpl implements MeetingRepository {
 	}
 
 	@Override
-	public Page<Meeting> getMeetings(String title, LocalDateTime meetingDate, MeetingStatus status,
+	public Page<Meeting> getMeetings(String title, LocalDateTime meetingDate, MeetingStatus status, Integer categoryId,
 		Pageable pageable) {
 
-		return meetingQueryRepository.findMeetings(title, meetingDate, status, pageable);
+		return meetingQueryRepository.findMeetings(title, meetingDate, status, categoryId, pageable);
 	}
 
 	@Override

--- a/src/main/java/com/example/momo/global/infrastructure/client/category/CategoryClient.java
+++ b/src/main/java/com/example/momo/global/infrastructure/client/category/CategoryClient.java
@@ -1,33 +1,36 @@
 package com.example.momo.global.infrastructure.client.category;
 
-import com.example.momo.global.common.dto.ApiResponse;
-import com.example.momo.global.infrastructure.client.category.dto.CategoryClientResponseDto;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.time.Duration;
+import java.util.List;
+
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import java.time.Duration;
-import java.util.List;
+import com.example.momo.global.common.dto.ApiResponse;
+import com.example.momo.global.infrastructure.client.category.dto.CategoryClientResponseDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class CategoryClient {
 
-	private final WebClient webClient;
 	private final static String CATEGORY_SERVICE_BASE_URI = "/api/v2/categories";
 	private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+	private final WebClient webClient;
 
-	public CategoryClientResponseDto getCategory(Long categoryId) {
+	public CategoryClientResponseDto getCategory(Integer categoryId) {
 		try {
 			ApiResponse<CategoryClientResponseDto> response = webClient
 				.get()
 				.uri(CATEGORY_SERVICE_BASE_URI + "/{categoryId}", categoryId)
 				.retrieve()
-				.bodyToMono(new ParameterizedTypeReference<ApiResponse<CategoryClientResponseDto>>() {})
+				.bodyToMono(new ParameterizedTypeReference<ApiResponse<CategoryClientResponseDto>>() {
+				})
 				.timeout(REQUEST_TIMEOUT)
 				.block();
 
@@ -56,7 +59,8 @@ public class CategoryClient {
 				.get()
 				.uri(CATEGORY_SERVICE_BASE_URI)
 				.retrieve()
-				.bodyToMono(new ParameterizedTypeReference<ApiResponse<List<CategoryClientResponseDto>>>() {})
+				.bodyToMono(new ParameterizedTypeReference<ApiResponse<List<CategoryClientResponseDto>>>() {
+				})
 				.timeout(REQUEST_TIMEOUT)
 				.block();
 

--- a/src/main/resources/db/migration/V6__Create_meetings_table.sql
+++ b/src/main/resources/db/migration/V6__Create_meetings_table.sql
@@ -9,7 +9,7 @@ CREATE TABLE meetings
     max_participants_count     int                             NOT NULL,
     min_enter_score            double                          NOT NULL,
     participation_fee          int                             NOT NULL,
-    version                    bigint      DEFAULT NULL,
+    version                    int      DEFAULT NULL,
     created_at                 datetime DEFAULT NULL,
     deleted_at                 datetime DEFAULT NULL,
     host_user_id               bigint                          NOT NULL,
@@ -19,5 +19,7 @@ CREATE TABLE meetings
     description                varchar(255)                    NOT NULL,
     location_name              varchar(255)                    NOT NULL,
     title                      varchar(255)                    NOT NULL,
-    status                     enum ('FINISHED','IN_PROGRESS') NOT NULL
+    status                     enum ('FINISHED','IN_PROGRESS') NOT NULL,
+
+    INDEX idx_meeting_deleted_category_status_date (is_deleted, category_id, status, meeting_date)
 );


### PR DESCRIPTION
### ⚡️ 구현 목록
- 인덱스 설정 전후 성능 테스트
- Meeting 테이블 복합 인덱스 (is_deleted, category_id, status, meeting_date)

항목 | 인덱스 없음 | 인덱스 적용 | 비교 결과
-- | -- | -- | --
샘플 수 (# Samples) | 20,841 | 43,785 | +110% 증가
평균 응답시간 (Average) | 1443ms | 732ms | ~49% 감소
중간값 (Median) | 1246ms | 665ms | ↓
90% Line | 1894ms | 1029ms | ↓
95% Line | 2402ms | 1250ms | ↓
99% Line | 5814ms | 2404ms | ↓
최소 응답시간 (Min) | 3ms | 1ms | ↓
최대 응답시간 (Max) | 6425ms | 3153ms | ↓
에러율 (Error %) | 4.80% | 2.28% | 절반 이상 감소
Throughput (처리량) | 669.5/sec | 1341.1/sec | 2배 증가
Received KB/sec | 3167.13 | 4570.30 | ↑
Sent KB/sec | 263.28 | 541.33 | ↑

이에 따른 복합 인덱스 적용

### ⚡️ 주의 사항
- 