### PR TITLE
Meeting 목록 조회 - userId client 요청

### DIFF
--- a/src/main/java/com/example/momo/domain/meeting/api/MeetingController.java
+++ b/src/main/java/com/example/momo/domain/meeting/api/MeetingController.java
@@ -98,6 +98,13 @@ public class MeetingController {
 		return ResponseEntity.ok(ApiResponse.success("모임 삭제가 성공적으로 완료되었습니다.", null));
 	}
 
+	@GetMapping("/user/{userId}")
+	public ResponseEntity<ApiResponse<List<MeetingResponseDto>>> getMeetingsByUserId(@PathVariable Long userId) {
+
+		List<MeetingResponseDto> response = meetingService.getMeetingsByUserId(userId);
+		return ResponseEntity.ok(ApiResponse.success("유저 식별자를 통한 모임 목록 조회가 성공적으로 완료되었습니다.", response));
+	}
+
 	// 모임 참가
 	@PostMapping("/{meetingId}/participants")
 	public ResponseEntity<ApiResponse<ParticipantResponseDto>> createParticipant(

--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingService.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingService.java
@@ -28,6 +28,8 @@ public interface MeetingService {
 
 	void deleteMeeting(Long meetingId, Long userId);
 
+	List<MeetingResponseDto> getMeetingsByUserId(Long userId);
+
 	/** Meeting Participant Service */
 
 	ParticipantResponseDto createParticipant(Long userId, Long meetingId);

--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
@@ -157,6 +157,13 @@ public class MeetingServiceImpl implements MeetingService {
 		));
 	}
 
+	@Override
+	public List<MeetingResponseDto> getMeetingsByUserId(Long userId) {
+		List<Meeting> meetings = meetingRepository.findMeetingsByUserId(userId);
+		
+		return meetings.stream().map(MeetingResponseDto::new).toList();
+	}
+
 	/**
 	 * Meeting Participant Service
 	 */

--- a/src/main/java/com/example/momo/domain/meeting/domain/MeetingRepository.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/MeetingRepository.java
@@ -20,6 +20,8 @@ public interface MeetingRepository {
 	Page<Meeting> getMeetings(String title, LocalDateTime meetingDate, MeetingStatus status, Integer categoryId,
 		Pageable pageable);
 
+	List<Meeting> findMeetingsByUserId(Long userId);
+
 	boolean existsById(Long id);
 
 	/* Meeting Participant Repository */
@@ -33,4 +35,5 @@ public interface MeetingRepository {
 	Optional<MeetingParticipant> findByMeetingIdAndUserId(Long meetingId, Long userId);
 
 	Optional<MeetingParticipant> findParticipantById(Long participantId);
+
 }

--- a/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingQueryRepository.java
+++ b/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingQueryRepository.java
@@ -1,6 +1,7 @@
 package com.example.momo.domain.meeting.infra.meeting;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,4 +13,6 @@ public interface MeetingQueryRepository {
 
 	Page<Meeting> findMeetings(String title, LocalDateTime meetingDate, MeetingStatus status, Integer categoryId,
 		Pageable pageable);
+
+	List<Meeting> findMeetingsByUserId(Long userId);
 }

--- a/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingQueryRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.example.momo.domain.meeting.infra.meeting;
 
 import static com.example.momo.domain.meeting.domain.QMeeting.*;
+import static com.example.momo.domain.meeting.domain.QMeetingParticipant.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -68,5 +69,15 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepository {
 			.fetchOne()).orElse(0L);
 
 		return new PageImpl<>(meetingContent, pageable, total);
+	}
+
+	@Override
+	public List<Meeting> findMeetingsByUserId(Long userId) {
+
+		return queryFactory
+			.selectFrom(meeting)
+			.join(meeting.participants, meetingParticipant)
+			.where(meetingParticipant.userId.eq(userId), meeting.isDeleted.isFalse())
+			.fetch();
 	}
 }

--- a/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/infra/meeting/MeetingRepositoryImpl.java
@@ -74,4 +74,9 @@ public class MeetingRepositoryImpl implements MeetingRepository {
 	public Optional<MeetingParticipant> findParticipantById(Long participantId) {
 		return meetingParticipantRepository.findById(participantId);
 	}
+
+	@Override
+	public List<Meeting> findMeetingsByUserId(Long userId) {
+		return meetingQueryRepository.findMeetingsByUserId(userId);
+	}
 }

--- a/src/main/java/com/example/momo/global/infrastructure/client/meeting/MeetingClient.java
+++ b/src/main/java/com/example/momo/global/infrastructure/client/meeting/MeetingClient.java
@@ -118,5 +118,33 @@ public class MeetingClient {
 			throw new MeetingClientException("참석자 목록 조회 중 오류가 발생했습니다: " + e.getMessage());
 		}
 	}
+
+	public List<MeetingClientResponseDto> getMeetingsByUserId(Long userId) {
+
+		try {
+			ApiResponse<List<MeetingClientResponseDto>> response = webClient
+				.get()
+				.uri(MEETING_SERVICE_BASE_URI + "/user/{userId}", userId)
+				.retrieve()
+				.bodyToMono(new ParameterizedTypeReference<ApiResponse<List<MeetingClientResponseDto>>>() {
+				})
+				.timeout(REQUEST_TIMEOUT)
+				.block();
+
+			if (response == null || !response.isSuccess()) {
+				return null;
+			}
+			return response.getData();
+		} catch (WebClientResponseException e) {
+
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+				return null;
+			}
+
+			throw new MeetingClientException("모임 목록 조회 중 오류가 발생했습니다. " + e.getMessage());
+		} catch (Exception e) {
+			throw new MeetingClientException("모임 목록 조회 중 오류가 발생했습니다. " + e.getMessage());
+		}
+	}
 }
 


### PR DESCRIPTION
### ⚡️기능 구현

- 모임 목록 조회 ( user가 참여하고 있는 모임들 )
- queryDsl을 통한 구현
- 테스트 완료
- isDeleted false값으로 기본적으로 넘김
- webClient 요청 시 받는 값은 MeetingClientResponseDto로 통일하여 구현