### PR TITLE
fix: UserCategory 엔티티의 user_id 필드 누락 문제 해결

### DIFF
--- a/src/main/java/com/example/momo/domain/user/domain/User.java
+++ b/src/main/java/com/example/momo/domain/user/domain/User.java
@@ -128,7 +128,7 @@ public class User extends BaseEntity {
 	public void updateCategories(List<Integer> categoryIds) {
 		this.categories.clear();
 		categoryIds.forEach(categoryId ->
-			this.categories.add(new UserCategory(categoryId))
+			this.categories.add(new UserCategory(this.id, categoryId))  // userId 전달
 		);
 	}
 }

--- a/src/main/java/com/example/momo/domain/user/domain/UserCategory.java
+++ b/src/main/java/com/example/momo/domain/user/domain/UserCategory.java
@@ -20,10 +20,14 @@ public class UserCategory {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
 	@Column(name = "category_id", nullable = false)
 	private Integer categoryId;
 
-	public UserCategory(Integer categoryId) {
+	public UserCategory(Long userId, Integer categoryId) {
+		this.userId = userId;
 		this.categoryId = categoryId;
 	}
 }


### PR DESCRIPTION
- UserCategory 엔티티에 userId 필드 추가
- UserCategory 생성자에 userId 매개변수 추가
- User.updateCategories() 메서드에서 userId 전달하도록 수정
- "Field 'user_id' doesn't have a default value" 오류 해결