### PR TITLE
feat: 사용자 모임 참여 취소(Cancel) 이벤트에 대한 PaymentEventListener 구현

### DIFF
--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
@@ -222,7 +222,8 @@ public class MeetingServiceImpl implements MeetingService {
 
 		ParticipantResponseDto responseDto = RetryUtil.retry(() -> removeParticipant(meetingId, participant), 5);
 
-		eventPublisher.publishEvent(new MeetingEvents.Cancel(meetingId, meeting.getHostUserId(), user.getNickname()));
+		eventPublisher.publishEvent(
+			new MeetingEvents.Cancel(meetingId, meeting.getHostUserId(), userId, user.getNickname()));
 
 		return responseDto;
 	}

--- a/src/main/java/com/example/momo/domain/payment/application/listener/PaymentEventListener.java
+++ b/src/main/java/com/example/momo/domain/payment/application/listener/PaymentEventListener.java
@@ -11,7 +11,11 @@ import com.example.momo.domain.meeting.domain.MeetingRepository;
 import com.example.momo.domain.meeting.exception.MeetingException;
 import com.example.momo.domain.meeting.exception.MeetingExceptionCode;
 import com.example.momo.domain.payment.application.PaymentService;
+import com.example.momo.domain.payment.domain.Payment;
+import com.example.momo.domain.payment.domain.PaymentRepository;
 import com.example.momo.domain.payment.domain.dto.CardPaymentTestRequestDto;
+import com.example.momo.domain.payment.domain.dto.RefundRequestDto;
+import com.example.momo.domain.payment.enums.PaymentStatus;
 import com.example.momo.domain.payment.exception.PaymentErrorCode;
 import com.example.momo.domain.payment.exception.PaymentException;
 import com.example.momo.domain.user.domain.User;
@@ -29,6 +33,7 @@ public class PaymentEventListener {
 
 	private final MeetingRepository meetingRepository;
 	private final UserRepository userRepository;
+	private final PaymentRepository paymentRepository;
 	private final PaymentService paymentService;
 	private final ApplicationEventPublisher eventPublisher;
 
@@ -75,6 +80,29 @@ public class PaymentEventListener {
 			eventPublisher.publishEvent(new MeetingEvents.ParticipationFailed(
 				event.meetingId(), event.userId(), null));
 		}
+	}
+
+	/* --------------------------------------------------
+ 참가자 개별 취소(Cancel) → 1건 환불
+  -------------------------------------------------- */
+	@Async
+	@EventListener
+	@Transactional
+	public void handleParticipantCancel(MeetingEvents.Cancel event) {
+
+		log.info("참가자 취소 이벤트 – meetingId={}, userId={}",
+			event.meetingId(), event.userId());
+
+		Payment payment = paymentRepository
+			.findByMeetingIdAndUserIdAndStatus(
+				event.meetingId(), event.userId(), PaymentStatus.COMPLETED)
+			.orElseThrow(() ->
+				new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+		paymentService.refundPayment(
+			payment.getId(),
+			event.userId(),
+			new RefundRequestDto("참가자 취소 환불"));
 	}
 
 	/**

--- a/src/main/java/com/example/momo/domain/payment/domain/PaymentRepository.java
+++ b/src/main/java/com/example/momo/domain/payment/domain/PaymentRepository.java
@@ -1,28 +1,33 @@
 package com.example.momo.domain.payment.domain;
 
-import com.example.momo.domain.payment.enums.PaymentStatus;
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.example.momo.domain.payment.enums.PaymentStatus;
+
 public interface PaymentRepository {
 
-  Payment save(Payment payment);
+	Payment save(Payment payment);
 
-  Optional<Payment> findById(Long id);
+	Optional<Payment> findById(Long id);
 
-  boolean existsByMeetingIdAndUserIdAndStatus(Long mId, Long uId, PaymentStatus st);
+	boolean existsByMeetingIdAndUserIdAndStatus(Long mId, Long uId, PaymentStatus st);
 
-  List<Payment> findByMeetingId(Long meetingId);
+	List<Payment> findByMeetingId(Long meetingId);
 
-  List<Payment> findByUserId(Long userId);
+	List<Payment> findByUserId(Long userId);
 
-  void delete(Payment payment);
+	void delete(Payment payment);
 
+	Page<Payment> searchPayments(Long meetingId,
+		Long userId,
+		PaymentStatus status,
+		Pageable pageable);
 
-  Page<Payment> searchPayments(Long meetingId,
-      Long userId,
-      PaymentStatus status,
-      Pageable pageable);
+	Optional<Payment> findByMeetingIdAndUserIdAndStatus(Long meetingId,
+		Long userId,
+		PaymentStatus status);
 }

--- a/src/main/java/com/example/momo/domain/payment/infra/PaymentJpaRepository.java
+++ b/src/main/java/com/example/momo/domain/payment/infra/PaymentJpaRepository.java
@@ -1,30 +1,36 @@
 package com.example.momo.domain.payment.infra;
 
-import com.example.momo.domain.payment.domain.Payment;
-import com.example.momo.domain.payment.enums.PaymentStatus;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.example.momo.domain.payment.domain.Payment;
+import com.example.momo.domain.payment.enums.PaymentStatus;
+
 public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
 
+	boolean existsByMeetingIdAndUserIdAndStatus(Long meetingId, Long userId, PaymentStatus status);
 
-  boolean existsByMeetingIdAndUserIdAndStatus(Long meetingId, Long userId, PaymentStatus status);
+	List<Payment> findByMeetingId(Long meetingId);
 
-  List<Payment> findByMeetingId(Long meetingId);
+	List<Payment> findByUserId(Long userId);
 
-  List<Payment> findByUserId(Long userId);
+	@Query("SELECT p FROM Payment p WHERE " +
+		"(:meetingId IS NULL OR p.meetingId = :meetingId) AND " +
+		"(:userId IS NULL OR p.userId = :userId) AND " +
+		"(:status IS NULL OR p.status = :status)")
+	Page<Payment> searchPayments(@Param("meetingId") Long meetingId,
+		@Param("userId") Long userId,
+		@Param("status") PaymentStatus status,
+		Pageable pageable);
 
+	Optional<Payment> findByMeetingIdAndUserIdAndStatus(Long meetingId,
+		Long userId,
+		PaymentStatus status);
 
-  @Query("SELECT p FROM Payment p WHERE " +
-      "(:meetingId IS NULL OR p.meetingId = :meetingId) AND " +
-      "(:userId IS NULL OR p.userId = :userId) AND " +
-      "(:status IS NULL OR p.status = :status)")
-  Page<Payment> searchPayments(@Param("meetingId") Long meetingId,
-      @Param("userId") Long userId,
-      @Param("status") PaymentStatus status,
-      Pageable pageable);
 }

--- a/src/main/java/com/example/momo/domain/payment/infra/PaymentRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/payment/infra/PaymentRepositoryImpl.java
@@ -1,55 +1,67 @@
 package com.example.momo.domain.payment.infra;
 
-import com.example.momo.domain.payment.domain.Payment;
-import com.example.momo.domain.payment.domain.PaymentRepository;
-import com.example.momo.domain.payment.enums.PaymentStatus;
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import com.example.momo.domain.payment.domain.Payment;
+import com.example.momo.domain.payment.domain.PaymentRepository;
+import com.example.momo.domain.payment.enums.PaymentStatus;
+
+import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
 public class PaymentRepositoryImpl implements PaymentRepository {
 
-  private final PaymentJpaRepository paymentJpaRepository;
+	private final PaymentJpaRepository paymentJpaRepository;
 
-  @Override
-  public Payment save(Payment payment) {
-    return paymentJpaRepository.save(payment);
-  }
+	@Override
+	public Payment save(Payment payment) {
+		return paymentJpaRepository.save(payment);
+	}
 
-  @Override
-  public Optional<Payment> findById(Long id) {
-    return paymentJpaRepository.findById(id);
-  }
+	@Override
+	public Optional<Payment> findById(Long id) {
+		return paymentJpaRepository.findById(id);
+	}
 
-  @Override
-  public boolean existsByMeetingIdAndUserIdAndStatus(Long meetingId, Long userId,
-      PaymentStatus status) {
-    return paymentJpaRepository.existsByMeetingIdAndUserIdAndStatus(meetingId, userId, status);
-  }
+	@Override
+	public boolean existsByMeetingIdAndUserIdAndStatus(Long meetingId, Long userId,
+		PaymentStatus status) {
+		return paymentJpaRepository.existsByMeetingIdAndUserIdAndStatus(meetingId, userId, status);
+	}
 
-  @Override
-  public List<Payment> findByMeetingId(Long meetingId) {
-    return paymentJpaRepository.findByMeetingId(meetingId);
-  }
+	@Override
+	public List<Payment> findByMeetingId(Long meetingId) {
+		return paymentJpaRepository.findByMeetingId(meetingId);
+	}
 
-  @Override
-  public List<Payment> findByUserId(Long userId) {
-    return paymentJpaRepository.findByUserId(userId);
-  }
+	@Override
+	public List<Payment> findByUserId(Long userId) {
+		return paymentJpaRepository.findByUserId(userId);
+	}
 
-  @Override
-  public void delete(Payment payment) {
-    paymentJpaRepository.delete(payment);
-  }
+	@Override
+	public void delete(Payment payment) {
+		paymentJpaRepository.delete(payment);
+	}
 
-  @Override
-  public Page<Payment> searchPayments(Long meetingId, Long userId, PaymentStatus status,
-      Pageable pageable) {
-    return paymentJpaRepository.searchPayments(meetingId, userId, status, pageable);
-  }
+	@Override
+	public Page<Payment> searchPayments(Long meetingId, Long userId, PaymentStatus status,
+		Pageable pageable) {
+		return paymentJpaRepository.searchPayments(meetingId, userId, status, pageable);
+	}
+
+	@Override
+	public Optional<Payment> findByMeetingIdAndUserIdAndStatus(Long meetingId,
+		Long userId,
+		PaymentStatus status) {
+		return paymentJpaRepository.findByMeetingIdAndUserIdAndStatus(meetingId,
+			userId,
+			status);
+	}
 }

--- a/src/main/java/com/example/momo/global/infrastructure/springEvent/MeetingEvents.java
+++ b/src/main/java/com/example/momo/global/infrastructure/springEvent/MeetingEvents.java
@@ -96,6 +96,7 @@ public class MeetingEvents {
 	public record Cancel(
 		Long meetingId,
 		Long hostUserId,
+		Long userId,
 		String participantNickname
 	) implements MeetingEvent {
 	}


### PR DESCRIPTION
## 구현 내용
- 사용자 모임 참여 취소(Cancel) 이벤트 수신 시, 결제 환불 처리 로직을 PaymentEventListener에 추가하였습니다.
- 급하게 구현 중에 관련 이벤트에 `userId`가 필요하여 필드에 추가했습니다. 

## 참고 사항
- 기존에 회의에서 결제 도메인의 비동기 이벤트 처리를 v3에서 진행하기로 결정했어서 생각을 못했는데,, 필요성이 확인되어 우선 구현하게 되었습니다.
- 혼선을 드려 죄송합니다. 
