### PR TITLE
사용자 평가 기능의 같은 모임 참가자 검증 오류 해결

### DIFF
--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -348,16 +348,30 @@ public class UserServiceImpl implements UserService {
 		// 참가자 ID 목록만 조회 (현재 Meeting API가 제공하는 방식)
 		List<Long> participantIds = meetingClient.getParticipantIds(meetingId);
 
+		// 디버그 로그 추가
+		log.info("=== 모임 참가자 검증 시작 ===");
+		log.info("meetingId: {}", meetingId);
+		log.info("reviewerId: {}", reviewerId);
+		log.info("targetUserId: {}", targetUserId);
+		log.info("participantIds from API: {}", participantIds);
+
 		if (participantIds == null || participantIds.isEmpty()) {
+			log.error("참가자 목록이 비어있음!");
 			throw new UserException(UserErrorCode.NOT_SAME_MEETING_PARTICIPANTS);
 		}
 
 		boolean reviewerParticipated = participantIds.contains(reviewerId);
 		boolean targetParticipated = participantIds.contains(targetUserId);
 
+		log.info("reviewerParticipated: {}", reviewerParticipated);
+		log.info("targetParticipated: {}", targetParticipated);
+
 		if (!reviewerParticipated || !targetParticipated) {
+			log.error("참가 검증 실패!");
 			throw new UserException(UserErrorCode.NOT_SAME_MEETING_PARTICIPANTS);
 		}
+
+		log.info("=== 모임 참가자 검증 완료 ===");
 	}
 
 	@Override

--- a/src/main/java/com/example/momo/global/infrastructure/client/meeting/MeetingClient.java
+++ b/src/main/java/com/example/momo/global/infrastructure/client/meeting/MeetingClient.java
@@ -1,6 +1,7 @@
 package com.example.momo.global.infrastructure.client.meeting;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -17,8 +18,6 @@ import com.example.momo.global.infrastructure.client.meeting.dto.ParticipantCoun
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.time.LocalDateTime;
 
 @Slf4j
 @Component
@@ -111,40 +110,66 @@ public class MeetingClient {
 	}
 
 	/**
-	 * 참가자 ID 목록 조회 (기존 API 그대로 사용)
-	 * 현재 Meeting API는 List<Long> 참가자 ID만 반환함
+	 * 참가자 ID 목록 조회 - UserService에서 평가 검증용으로 사용
+	 * Meeting API에서 ParticipantResponseDto 리스트를 받아서 userId만 추출
 	 */
 	public List<Long> getParticipantIds(Long meetingId) {
 		try {
-			ApiResponse<List<Long>> response = webClient
+			log.info("=== MeetingClient.getParticipantIds 시작 ===");
+			log.info("요청 meetingId: {}", meetingId);
+			log.info("요청 URL: {}", MEETING_SERVICE_BASE_URI + "/" + meetingId + "/participants");
+
+			ApiResponse<List<ParticipantClientResponseDto>> response = webClient
 				.get()
 				.uri(MEETING_SERVICE_BASE_URI + "/{meetingId}/participants", meetingId)
 				.retrieve()
-				.bodyToMono(new ParameterizedTypeReference<ApiResponse<List<Long>>>() {
+				.bodyToMono(new ParameterizedTypeReference<ApiResponse<List<ParticipantClientResponseDto>>>() {
 				})
 				.timeout(REQUEST_TIMEOUT)
 				.block();
 
-			if (response == null || !response.isSuccess()) {
+			log.info("API 응답 전체: {}", response);
+
+			if (response == null) {
+				log.error("응답이 null!");
 				return List.of();
 			}
 
-			log.debug("참석자 ID 목록 조회 성공: meetingId={}, count={}", meetingId, response.getData().size());
-			return response.getData();
-
-		} catch (WebClientResponseException e) {
-			if (e.getStatusCode().value() == 404) {
-				log.debug("참석자 목록을 찾을 수 없습니다: meetingId={}", meetingId);
+			if (!response.isSuccess()) {
+				log.error("응답 실패: success={}, message={}", response.isSuccess(), response.getMessage());
 				return List.of();
 			}
 
-			log.error("참석자 목록 조회 실패: meetingId={}, status={}, error={}",
-				meetingId, e.getStatusCode(), e.getMessage());
-			throw new MeetingClientException("참석자 목록 조회 중 오류가 발생했습니다: " + e.getMessage());
+			if (response.getData() == null) {
+				log.error("응답 데이터가 null!");
+				return List.of();
+			}
+
+			log.info("응답 데이터 크기: {}", response.getData().size());
+			log.info("응답 데이터 내용: {}", response.getData());
+
+			List<Long> participantIds = response.getData().stream()
+				.map(participant -> {
+					log.info("참가자 정보: id={}, meetingId={}, participantId={}, attendance={}",
+						participant.getId(), participant.getMeetingId(),
+						participant.getParticipantId(),
+						participant.isAttendanceStatus()); // getUserId() -> getParticipantId()
+					return participant.getParticipantId(); // getUserId() -> getParticipantId()
+				})
+				.toList();
+
+			log.info("최종 추출된 participantIds: {}", participantIds);
+			log.info("=== MeetingClient.getParticipantIds 완료 ===");
+			return participantIds;
+
+		} catch (Exception e) {
+			log.error("=== MeetingClient.getParticipantIds 오류 ===", e);
+			return List.of();
 		}
 	}
 
-	public ParticipantCountClientResponseDto getParticipantCount(Long meetingId, Boolean attendance, LocalDateTime createdAt) {
+	public ParticipantCountClientResponseDto getParticipantCount(Long meetingId, Boolean attendance,
+		LocalDateTime createdAt) {
 		try {
 			ApiResponse<ParticipantCountClientResponseDto> response = webClient
 				.get()
@@ -154,7 +179,8 @@ public class MeetingClient {
 					.queryParam("createdAt", createdAt)
 					.build(meetingId))
 				.retrieve()
-				.bodyToMono(new ParameterizedTypeReference<ApiResponse<ParticipantCountClientResponseDto>>() {})
+				.bodyToMono(new ParameterizedTypeReference<ApiResponse<ParticipantCountClientResponseDto>>() {
+				})
 				.timeout(REQUEST_TIMEOUT)
 				.block();
 

--- a/src/main/java/com/example/momo/global/infrastructure/client/meeting/dto/ParticipantClientResponseDto.java
+++ b/src/main/java/com/example/momo/global/infrastructure/client/meeting/dto/ParticipantClientResponseDto.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 public class ParticipantClientResponseDto {
 	private Long id;
 	private Long meetingId;
-	private Long userId;
+	private Long participantId;
 	private boolean attendanceStatus;
 }


### PR DESCRIPTION
- MeetingClient.getParticipantIds에서 ParticipantClientResponseDto 타입 매핑 수정
- userId 필드를 participantId로 올바르게 매핑하여 빈 배열 반환 문제 해결
- 같은 모임 참가자간 평가 기능 정상 작동 확인