### PR TITLE
feat: 기본 RabbitMQ 설정 및 간단한 테스트 환경 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,13 @@ dependencies {
 
     // OpenTelemetry
     implementation("io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter")
+
+    // RabbitMQ 지원 (spring-amqp + spring-rabbit)
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    // JSON 직렬화/역직렬화용 Jackson
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
 }
 
 dependencyManagement {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "8888:8888"
     volumes:
       - ./otel-config.yml:/etc/otel/config.yaml
-    command: ["--config=/etc/otel/config.yaml"]
+    command: [ "--config=/etc/otel/config.yaml" ]
     depends_on:
       - jaeger
 
@@ -22,3 +22,18 @@ services:
     environment:
       COLLECTOR_OTLP_ENABLED: true
       LOG_LEVEL: debug
+
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    container_name: rabbitmq
+    ports:
+      - "5672:5672"     # AMQP (Spring에서 연결)
+      - "15672:15672"   # RabbitMQ Web 관리 콘솔
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS}
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+
+volumes:
+  rabbitmq_data:

--- a/src/main/java/com/example/momo/global/config/RabbitMQConfig.java
+++ b/src/main/java/com/example/momo/global/config/RabbitMQConfig.java
@@ -1,0 +1,87 @@
+package com.example.momo.global.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+	public static final String QUEUE_NAME = "momo.queue";
+	public static final String EXCHANGE_NAME = "momo.exchange";
+	public static final String ROUTING_KEY = "momo.key";
+
+	//durable queue (서버 재시작에도 유지됨)
+	//큐 메타데이터(이름,ttl,바인딩 등)이 유지됨
+	//큐 안에 아직 소비되지 않은 메세지들도 유지됨
+
+	@Bean
+	public Queue queue() {
+		return QueueBuilder.durable(QUEUE_NAME)
+			.withArgument("x-dead-letter-exchange", "momo.dlx")  //DLX 지정
+			//실패 시 메세지를 보낼 교환기
+			.withArgument("x-dead-letter-routing-key", "momo.dlx.key")
+			//dlq 라우팅 키
+			.withArgument("x-message-ttl", 10000)  //10초 후 만료
+			//메세지가 큐에 도달하고 처리되지 않으면 ttl 시간 후 dlq로 이동
+			.build();
+	}
+
+	//DLX (Dead Letter Exchange)
+	@Bean
+	public TopicExchange deadLetterExchange() {
+		return new TopicExchange("momo.dlx");
+	}
+
+	//DLQ (실패 메시지 수신용 큐)
+	@Bean
+	public Queue deadLetterQueue() {
+		return new Queue("momo.dlq", true);
+	}
+
+	//DLQ Binding
+	@Bean
+	public Binding deadLetterBinding() {
+		return BindingBuilder
+			.bind(deadLetterQueue())
+			.to(deadLetterExchange())
+			.with("momo.dlx.key");
+	}
+
+	//topic exchange 생성
+	@Bean
+	public TopicExchange exchange() {
+		return new TopicExchange(EXCHANGE_NAME);
+	}
+
+	//queue와 exchange를 routing key로 연결
+	@Bean
+	public Binding binding() {
+		return BindingBuilder
+			.bind(queue())
+			.to(exchange())
+			.with("momo.#");
+	}
+
+	//json 메세지 컨버터
+	@Bean
+	public MessageConverter jsonMessageConverter() {
+		return new Jackson2JsonMessageConverter();
+	}
+
+	//rabbitTemplate에 컨버터 적용
+	@Bean
+	public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+		RabbitTemplate template = new RabbitTemplate(connectionFactory);
+		template.setMessageConverter(jsonMessageConverter());
+		return template;
+	}
+}

--- a/src/main/java/com/example/momo/global/rabbitMQ/MessageConsumer.java
+++ b/src/main/java/com/example/momo/global/rabbitMQ/MessageConsumer.java
@@ -1,0 +1,23 @@
+package com.example.momo.global.rabbitMQ;
+
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class MessageConsumer {
+
+	//@RabbitListener(queues = RabbitMQConfig.QUEUE_NAME)
+	public void receive(String message) {
+		try {
+			log.info("Received message: {}", message);
+			// 메시지 처리 로직
+		} catch (Exception e) {
+			log.error("Error processing message: {}", message, e);
+			// 필요시 DLQ(Dead Letter Queue)로 전송
+			throw new AmqpRejectAndDontRequeueException("Failed to process message", e);
+		}
+	}
+}

--- a/src/main/java/com/example/momo/global/rabbitMQ/MessageProducer.java
+++ b/src/main/java/com/example/momo/global/rabbitMQ/MessageProducer.java
@@ -1,0 +1,24 @@
+package com.example.momo.global.rabbitMQ;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+import com.example.momo.global.config.RabbitMQConfig;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class MessageProducer {
+
+	private final RabbitTemplate rabbitTemplate;
+
+	//메세지를 exchange에 publish
+	public void send(String message) {
+		rabbitTemplate.convertAndSend(
+			RabbitMQConfig.EXCHANGE_NAME,
+			RabbitMQConfig.ROUTING_KEY,
+			message
+		);
+	}
+}

--- a/src/main/java/com/example/momo/global/rabbitMQ/TestController.java
+++ b/src/main/java/com/example/momo/global/rabbitMQ/TestController.java
@@ -1,0 +1,20 @@
+package com.example.momo.global.rabbitMQ;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class TestController {
+
+	private final MessageProducer producer;
+
+	@PostMapping("/send")
+	public String sendMessage(@RequestBody String message) {
+		producer.send(message);
+		return "보냄";
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,12 @@ spring:
     basename: validations, messages
     encoding: UTF-8
 
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: ${RABBITMQ_USER}
+    password: ${RABBITMQ_PASS}
+
 toss:
   payments:
     secret-key: ${TOSS_SECRET_KEY}
@@ -70,3 +76,4 @@ otel:
 logging:
   level:
     io.opentelemetry.exporter: DEBUG
+


### PR DESCRIPTION
### 변경 사항
- RabbitMQ exchange, queue, DLX, TTL 설정.
- 간단한 메시지 송수신 로직 구현 및 테스트 컨트롤러 작성.
-  application.yml 및 docker-compose.yml 환경변수화해서 반영.

----

### 참고사항

  .env 파일에 추가 사항
  
    #rabbitMQ
    RABBITMQ_USER=계정
    RABBITMQ_PASS=계정 비밀번호

- 로컬 환경에서는 임의의 계정/비밀번호를 지정해서 사용하면 됩니다.

- 최초 실행 시 해당 계정으로 RabbitMQ 내부에 사용자 계정이 자동 생성됩니다.

----

### RabbitMQ 관리 콘솔

http://localhost:15672/

- 해당 URL은 RabbitMQ 서버를 관리 및 모니터링할 수 있는 웹 기반 콘솔입니다.

- 위에서 설정한 RABBITMQ_USER / RABBITMQ_PASS를 입력하여 로그인할 수 있습니다.

- Queue 상태 확인, 메시지 발행/소비 테스트 등의 작업이 가능합니다.

