### PR TITLE
User 도메인 점수 계산 로직 개선 및 애그리거트 패턴 적용하여 도메인 모델의 일관성과 캡슐화 강화

### DIFF
--- a/rabbitmq-naming-convention.md
+++ b/rabbitmq-naming-convention.md
@@ -52,8 +52,8 @@ public class RabbitExchangeNames {
 
 // RoutingKeys.java
 public class RoutingKeys {
-	public static final String USER_CREATED = "user.created";
-	public static final String USER_WITHDRAWN = "user.withdrawn";
+	public static final String USER_CREATED_KEY = "user.created.key";
+	public static final String USER_WITHDRAWN_KEY = "user.withdrawn.key";
 }
 
 // QueueNames.java

--- a/src/main/java/com/example/momo/domain/auth/event/config/AuthRabbitMQConfig.java
+++ b/src/main/java/com/example/momo/domain/auth/event/config/AuthRabbitMQConfig.java
@@ -1,10 +1,8 @@
 package com.example.momo.domain.auth.event.config;
 
-
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
-import org.springframework.amqp.core.Exchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.core.TopicExchange;
@@ -32,10 +30,12 @@ public class AuthRabbitMQConfig {
 	}
 
 	@Bean
-	public Queue authUserDLQ(){ return new Queue(AUTH_USER_DLQ,true); }
+	public Queue authUserDLQ() {
+		return new Queue(AUTH_USER_DLQ, true);
+	}
 
 	@Bean
-	public DirectExchange authUserDLX(){
+	public DirectExchange authUserDLX() {
 		return new DirectExchange(AUTH_USER_DLX, true, false);
 	}
 
@@ -44,7 +44,7 @@ public class AuthRabbitMQConfig {
 		return BindingBuilder
 			.bind(authUserEventsQueue())
 			.to(new TopicExchange(RabbitExchangeNames.USER_EVENTS, true, false))
-			.with(RoutingKeys.USER_WITHDRAWN);
+			.with(RoutingKeys.USER_WITHDRAWN_KEY);
 	}
 
 	@Bean

--- a/src/main/java/com/example/momo/domain/auth/event/consumer/AuthUserEventConsumer.java
+++ b/src/main/java/com/example/momo/domain/auth/event/consumer/AuthUserEventConsumer.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.momo.domain.auth.event.config.AuthRabbitMQConfig;
 import com.example.momo.domain.auth.infra.UserSocialRepository;
 import com.example.momo.domain.auth.slack.SlackNotifier;
-import com.example.momo.global.rabbitmq.dto.UserEventMessage;
+import com.example.momo.global.rabbitmq.dto.User.UserEventMessage;
 import com.example.momo.global.rabbitmq.dto.common.EventWrapper;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/momo/domain/auth/event/consumer/AuthUserEventConsumer.java
+++ b/src/main/java/com/example/momo/domain/auth/event/consumer/AuthUserEventConsumer.java
@@ -3,6 +3,7 @@ package com.example.momo.domain.auth.event.consumer;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.rabbit.annotation.RabbitHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.annotation.Recover;
@@ -35,10 +36,44 @@ public class AuthUserEventConsumer {
 	)
 	@RabbitHandler
 	@Transactional
-	public void handleUserEvent(EventWrapper<?> eventWrapper) {
-		switch (eventWrapper.type()) {
-			case "user.withdrawn" -> handleUserWithdrawn(eventWrapper);
-			default -> throw new RuntimeException("지원하지 않는 이벤트 타입: " + eventWrapper.type());
+	public void handleUserEvent(EventWrapper<?> eventWrapper,
+		@Header(value = "correlationId", required = false) String correlationId) {
+
+		// correlationId가 없으면 기본값 생성
+		if (correlationId == null) {
+			correlationId = "unknown-" + eventWrapper.uuId();
+		}
+
+		// 1. EventWrapper 기본 검증
+		if (eventWrapper == null) {
+			log.error("[{}] EventWrapper가 null입니다", correlationId);
+			throw new IllegalArgumentException("EventWrapper cannot be null");
+		}
+
+		// 2. type 검증
+		String eventType = eventWrapper.type();
+		if (eventType == null || eventType.trim().isEmpty()) {
+			log.error("[{}] 이벤트 타입이 null이거나 비어있습니다: eventId={}",
+				correlationId, eventWrapper.uuId());
+			throw new IllegalArgumentException("Event type cannot be null or empty");
+		}
+
+		// 3. data 검증
+		if (eventWrapper.data() == null) {
+			log.error("[{}] 이벤트 데이터가 null입니다: eventType={}, eventId={}",
+				correlationId, eventType, eventWrapper.uuId());
+			throw new IllegalArgumentException("Event data cannot be null");
+		}
+
+		log.info("[{}] 이벤트 처리 시작: eventType={}, eventId={}",
+			correlationId, eventType, eventWrapper.uuId());
+
+		switch (eventType) {
+			case "user.withdrawn" -> handleUserWithdrawn(eventWrapper, correlationId);
+			default -> {
+				log.error("[{}] 지원하지 않는 이벤트 타입: {}", correlationId, eventType);
+				throw new UnsupportedOperationException("지원하지 않는 이벤트 타입: " + eventType);
+			}
 		}
 	}
 
@@ -46,35 +81,84 @@ public class AuthUserEventConsumer {
 	 * 메시지 소비를 3번 시도하고 실패하면 DLQ로 이동
 	 */
 	@Recover
-	public void recover(Exception e, EventWrapper<?> eventWrapper) {
-		// Retryable 의 최대 횟수를 모두 실패하면 error 로그를 남김.
-		log.error("User 이벤트 처리 실패: eventType={}, eventId={}, error={}",
-			eventWrapper.type(), eventWrapper.uuId(), e.getMessage(), e);
+	public void recover(Exception e, EventWrapper<?> eventWrapper, String correlationId) {
+		// correlationId가 없으면 기본값
+		if (correlationId == null) {
+			correlationId = "unknown-" + eventWrapper.uuId();
+		}
 
-		// Slack 메시지를 보냄
+		log.error("[{}] User 이벤트 처리 실패: eventType={}, eventId={}, error={}",
+			correlationId, eventWrapper.type(), eventWrapper.uuId(), e.getMessage(), e);
+
+		// Slack 알림에도 correlationId 포함
 		slackNotifier.notifyMessageConsumeFailure(
 			this.getClass().getSimpleName(),
-			eventWrapper.type(),
+			eventWrapper.type() + " (correlationId: " + correlationId + ")",
 			AuthRabbitMQConfig.AUTH_USER_EVENTS_QUEUE,
 			e
 		);
 
-		// Slack 메시지를 보내고 DLQ로 이동
 		throw new AmqpRejectAndDontRequeueException(
-			"Retry 실패, DLQ로 이동: eventType=" + eventWrapper.type(), e);
+			"Retry 실패, DLQ로 이동: eventType=" + eventWrapper.type() + ", correlationId=" + correlationId, e);
 	}
 
 	/**
 	 * 회원탈퇴 이벤트 처리
 	 */
-	private void handleUserWithdrawn(EventWrapper<?> eventWrapper) {
-		// RabbitMQ 에서 자동 역직렬화된 데이터를 직접 캐스팅
-		UserEventMessage.UserWithdrawnData data = (UserEventMessage.UserWithdrawnData)eventWrapper.data();
+	private void handleUserWithdrawn(EventWrapper<?> eventWrapper, String correlationId) {
+		try {
+			// 데이터 타입 캐스팅 검증
+			if (!(eventWrapper.data() instanceof UserEventMessage.UserWithdrawnData)) {
+				log.error("[{}] 잘못된 데이터 타입: expected=UserWithdrawnData, actual={}",
+					correlationId, eventWrapper.data().getClass().getSimpleName());
+				throw new IllegalArgumentException("잘못된 데이터 타입입니다");
+			}
 
-		log.info("회원탈퇴 이벤트 수신: userId={}, email={}, eventId={}", data.userId(), data.email(), eventWrapper.uuId());
+			UserEventMessage.UserWithdrawnData data = (UserEventMessage.UserWithdrawnData)eventWrapper.data();
 
-		userSocialRepository.deleteAllByUserId(data.userId());
+			// 필수 필드 검증
+			validateUserWithdrawnData(data, correlationId);
 
-		log.info("계정({})에 연동된 소셜 로그인을 모두 삭제했습니다.", data.email());
+			log.info("[{}] 회원탈퇴 이벤트 수신: userId={}, email={}, eventId={}",
+				correlationId, data.userId(), data.email(), eventWrapper.uuId());
+
+			// 비즈니스 로직 실행
+			userSocialRepository.deleteAllByUserId(data.userId());
+
+			log.info("[{}] 계정({})에 연동된 소셜 로그인을 모두 삭제했습니다.",
+				correlationId, data.email());
+
+		} catch (ClassCastException e) {
+			log.error("[{}] 데이터 캐스팅 실패: {}", correlationId, e.getMessage());
+			throw new IllegalArgumentException("이벤트 데이터 형식이 올바르지 않습니다", e);
+		} catch (Exception e) {
+			log.error("[{}] 소셜 로그인 삭제 실패: error={}", correlationId, e.getMessage());
+			throw e;
+		}
+	}
+
+	/**
+	 * UserWithdrawnData 필수 필드 검증
+	 */
+	private void validateUserWithdrawnData(UserEventMessage.UserWithdrawnData data, String correlationId) {
+		if (data.userId() == null) {
+			log.error("[{}] userId가 null입니다", correlationId);
+			throw new IllegalArgumentException("userId는 필수입니다");
+		}
+
+		if (data.userId() <= 0) {
+			log.error("[{}] 잘못된 userId: {}", correlationId, data.userId());
+			throw new IllegalArgumentException("userId는 양수여야 합니다");
+		}
+
+		if (data.email() == null || data.email().trim().isEmpty()) {
+			log.error("[{}] email이 null이거나 비어있습니다: userId={}", correlationId, data.userId());
+			throw new IllegalArgumentException("email은 필수입니다");
+		}
+
+		if (data.nickname() == null || data.nickname().trim().isEmpty()) {
+			log.error("[{}] nickname이 null이거나 비어있습니다: userId={}", correlationId, data.userId());
+			throw new IllegalArgumentException("nickname은 필수입니다");
+		}
 	}
 }

--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -249,7 +249,7 @@ public class UserServiceImpl implements UserService {
 
 		boolean allValid = new HashSet<>(validCategoryIds).containsAll(categoryIds);
 		if (!allValid) {
-			log.warn("유효하지 않은 카테고리 ID 포함: categoryIds={}", categoryIds);
+			log.info("유효하지 않은 카테고리 ID 포함: categoryIds={}", categoryIds);
 			throw new UserException(UserErrorCode.INVALID_CATEGORY_IDS);
 		}
 
@@ -271,13 +271,13 @@ public class UserServiceImpl implements UserService {
 
 		// 1. 현재 비밀번호 확인
 		if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
-			log.warn("현재 비밀번호 불일치: userId={}", userId);
+			log.info("현재 비밀번호 불일치: userId={}", userId);
 			throw new UserException(UserErrorCode.PASSWORD_MISMATCH);
 		}
 
 		// 2. 새 비밀번호 확인
 		if (!request.newPassword().equals(request.confirmPassword())) {
-			log.warn("새 비밀번호 확인 불일치: userId={}", userId);
+			log.info("새 비밀번호 확인 불일치: userId={}", userId);
 			throw new UserException(UserErrorCode.PASSWORD_CONFIRM_MISMATCH);
 		}
 
@@ -297,7 +297,7 @@ public class UserServiceImpl implements UserService {
 
 		// 중복 검사 (자기 자신 제외)
 		if (userRepository.isDuplicateNickname(request.nickname(), userId)) {
-			log.warn("닉네임 중복: nickname={}", request.nickname());
+			log.info("닉네임 중복: nickname={}", request.nickname());
 			throw new UserException(UserErrorCode.DUPLICATE_NICKNAME);
 		}
 
@@ -338,7 +338,7 @@ public class UserServiceImpl implements UserService {
 
 		// 1. 자기 자신 팔로우 방지
 		if (followerId.equals(followingId)) {
-			log.warn("자기 자신 팔로우 시도: userId={}", followerId);
+			log.info("자기 자신 팔로우 시도: userId={}", followerId);
 			throw new UserException(UserErrorCode.CANNOT_FOLLOW_SELF);
 		}
 
@@ -351,7 +351,7 @@ public class UserServiceImpl implements UserService {
 			.anyMatch(follow -> follow.getFollowingId().equals(followingId));
 
 		if (alreadyFollowing) {
-			log.warn("이미 팔로우 중: followerId={}, followingId={}", followerId, followingId);
+			log.info("이미 팔로우 중: followerId={}, followingId={}", followerId, followingId);
 			throw new UserException(UserErrorCode.ALREADY_FOLLOWING);
 		}
 
@@ -385,7 +385,7 @@ public class UserServiceImpl implements UserService {
 
 		// 1. 자기 자신 언팔로우 방지
 		if (followerId.equals(followingId)) {
-			log.warn("자기 자신 언팔로우 시도: userId={}", followerId);
+			log.info("자기 자신 언팔로우 시도: userId={}", followerId);
 			throw new UserException(UserErrorCode.CANNOT_FOLLOW_SELF);
 		}
 
@@ -398,7 +398,7 @@ public class UserServiceImpl implements UserService {
 			.anyMatch(follow -> follow.getFollowingId().equals(followingId));
 
 		if (!isFollowing) {
-			log.warn("팔로우하지 않은 사용자: followerId={}, followingId={}", followerId, followingId);
+			log.info("팔로우하지 않은 사용자: followerId={}, followingId={}", followerId, followingId);
 			throw new UserException(UserErrorCode.NOT_FOLLOWING);
 		}
 
@@ -478,7 +478,7 @@ public class UserServiceImpl implements UserService {
 		}
 
 		// 평가자 존재 확인
-		User reviewer = validateAndGetUser(reviewerId);
+		validateAndGetUser(reviewerId);
 
 		// 평가 대상자 존재 확인
 		User targetUser = userRepository.findByIdAndIsDeletedFalse(targetUserId)
@@ -557,10 +557,15 @@ public class UserServiceImpl implements UserService {
 
 		// 6. 점수 업데이트
 		user.updateScore(totalScore);
+
+		log.info("사용자 점수 재계산 완료: userId={}, 이전점수={}, 새점수={}, " +
+				"평점점수={}, 참석률점수={}, 활동도점수={}",
+			userId, oldScore, totalScore, ratingScore, attendanceScore, activityScore);
 	}
 
 	/**
 	 * MeetingClient를 통해 사용자의 모임 참가 통계 조회
+	 * 실제 출석 정보를 활용하여 정확한 통계 계산
 	 */
 	private UserMeetingStatsDto getUserMeetingStats(Long userId) {
 		// MeetingClient를 통해 사용자가 참가한 모임 목록 조회
@@ -584,43 +589,50 @@ public class UserServiceImpl implements UserService {
 		for (MeetingClientResponseDto meeting : userMeetings) {
 			// 각 모임의 참가자 중에서 해당 사용자의 출석 정보 확인
 			// 현재는 참가자 상세 정보를 개별 조회해야 함 (N+1 문제)
+			// TODO : 모임쪽에서 N+1 해결한 메서드(배치 API)를 제공해주면 수정 예정
 			ParticipantClientResponseDto userParticipant = meetingClient.getParticipant(meeting.getId(), userId);
 
-			if (userParticipant != null) {
-				// 출석 여부 확인
-				if (userParticipant.isAttendanceStatus()) {
-					attendedMeetings++;
-				}
+			if (userParticipant != null && userParticipant.isAttendanceStatus()) {
+				attendedMeetings++;
 			}
 
-			// 최근 3개월 참가 여부 확인 (모임 생성일 기준)
-			if (meeting.getMeetingDate().isAfter(threeMonthsAgo)) {
+			// 최근 3개월 참가 여부 확인 (모임 날짜 기준)
+			if (meeting.getMeetingDate() != null &&
+				meeting.getMeetingDate().isAfter(threeMonthsAgo)) {
 				recentParticipation++;
 			}
 		}
+
+		log.debug("모임 통계 계산 완료: userId={}, 총참가={}, 출석={}, 최근3개월={}",
+			userId, totalParticipation, attendedMeetings, recentParticipation);
 
 		return new UserMeetingStatsDto(totalParticipation, attendedMeetings, recentParticipation);
 	}
 
 	/**
 	 * 평점 기반 점수 계산 (60%)
-	 * 평점 4.5/5.0 → (4.5/5.0) * 60 = 54점
-	 * 주의: 이 메서드는 평가가 있는 사용자에 대해서만 호출됨
+	 * 신규 사용자는 기본 점수 제공
 	 */
 	private double calculateRatingScore(User user) {
-		// 평가받은 사용자라면 ratings가 있어야 함
-		if (user.getRatings().isEmpty()) {
-			throw new IllegalStateException("평가 점수를 계산하려 하는데 평가가 없습니다!");
+		if (user.getRatings() == null || user.getRatings().isEmpty()) {
+			// 신규 사용자 기본 점수: 2.5/5.0 * 60 = 30점
+			log.debug("신규 사용자 기본 평점 점수 적용: userId={}", user.getId());
+			return 30.0;
 		}
 
 		// 평균 평점 계산
 		double averageRating = user.getRatings().stream()
 			.mapToInt(UserRating::getRatingScore)
 			.average()
-			.orElseThrow(() -> new IllegalStateException("평가 데이터가 비어있습니다!"));
+			.orElse(2.5); // 안전장치
 
 		// 5점 만점을 60점 만점으로 변환
-		return (averageRating / 5.0) * 60.0;
+		double score = (averageRating / 5.0) * 60.0;
+
+		log.debug("평점 점수 계산: userId={}, 평균평점={}, 점수={}",
+			user.getId(), averageRating, score);
+
+		return score;
 	}
 
 	/**
@@ -629,11 +641,21 @@ public class UserServiceImpl implements UserService {
 	 */
 	private double calculateAttendanceScore(UserMeetingStatsDto meetingStats) {
 		if (meetingStats.totalParticipation() == 0) {
-			throw new IllegalStateException("평가받은 사용자인데 참가한 모임이 없습니다. 데이터 정합성 오류!");
+			// 참가한 모임이 없는 경우 기본 점수: 50% 참석률 = 15점
+			log.debug("모임 참가 이력 없음 - 기본 참석률 점수 적용");
+			return 15.0;
 		}
 
-		// 30점 만점으로 변환
-		return meetingStats.getAttendanceRate() * 30.0;
+		// 참석률을 30점 만점으로 변환
+		double attendanceRate = meetingStats.getAttendanceRate();
+		double score = attendanceRate * 30.0;
+
+		log.debug("참석률 점수 계산: 총참가={}, 출석={}, 참석률={}, 점수={}",
+			meetingStats.totalParticipation(),
+			meetingStats.attendedMeetings(),
+			attendanceRate, score);
+
+		return score;
 	}
 
 	/**
@@ -642,14 +664,22 @@ public class UserServiceImpl implements UserService {
 	 */
 	private double calculateActivityScore(UserMeetingStatsDto meetingStats) {
 		double monthlyAverage = meetingStats.getMonthlyAverage();
+		double score;
 
 		// 활동도 점수 계산
 		if (monthlyAverage >= 2.0) {
-			return 10.0; // 월 평균 2회 이상
+			score = 10.0; // 월 평균 2회 이상 - 매우 활발
 		} else if (monthlyAverage >= 1.0) {
-			return 7.0;  // 월 평균 1-2회
+			score = 7.0;  // 월 평균 1-2회 - 보통
+		} else if (monthlyAverage > 0) {
+			score = 3.0;  // 월 평균 1회 미만 - 저조
 		} else {
-			return 3.0;  // 월 평균 1회 미만 (0회 포함)
+			score = 0.0;  // 최근 활동 없음
 		}
+
+		log.debug("활동도 점수 계산: 최근3개월참가={}, 월평균={}, 점수={}",
+			meetingStats.recentParticipation(), monthlyAverage, score);
+
+		return score;
 	}
 }

--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -26,7 +26,6 @@ import com.example.momo.domain.user.application.dto.UserResponseDto;
 import com.example.momo.domain.user.application.dto.WithdrawRequestDto;
 import com.example.momo.domain.user.domain.User;
 import com.example.momo.domain.user.domain.UserCategory;
-import com.example.momo.domain.user.domain.UserFollow;
 import com.example.momo.domain.user.domain.UserRating;
 import com.example.momo.domain.user.domain.UserRepository;
 import com.example.momo.domain.user.event.springEvent.UserEvents;
@@ -357,11 +356,8 @@ public class UserServiceImpl implements UserService {
 		}
 
 		// 4. 팔로우 관계 생성 및 카운트 증가
-		UserFollow userFollow = new UserFollow(followerId, followingId);
-		follower.getFollowings().add(userFollow);
-
-		follower.incrementFollowingCount();     // 내 팔로잉 수 +1
-		following.incrementFollowerCount();     // 상대방 팔로워 수 +1
+		follower.addFollowing(followingId);        // 팔로잉 추가 + 카운트 증가
+		following.increaseFollowerCount();         // 팔로워 카운트만 증가
 
 		// 5. 아웃박스 이벤트 저장
 		userOutboxService.saveUserFollowedEvent(
@@ -407,14 +403,8 @@ public class UserServiceImpl implements UserService {
 		}
 
 		// 4. 팔로우 관계 삭제 및 카운트 감소
-		int deletedCount = userRepository.deleteUserFollow(followerId, followingId);
-		if (deletedCount == 0) {
-			log.error("팔로우 관계 삭제 실패: followerId={}, followingId={}", followerId, followingId);
-			throw new UserException(UserErrorCode.NOT_FOLLOWING);
-		}
-
-		follower.decrementFollowingCount();     // 내 팔로잉 수 -1
-		following.decrementFollowerCount();     // 상대방 팔로워 수 -1
+		follower.removeFollowing(followingId);     // 팔로잉 제거 + 카운트 감소
+		following.decreaseFollowerCount();         // 팔로워 카운트만 감소
 
 		log.info("언팔로우 완료: followerId={}, followingId={}", followerId, followingId);
 	}
@@ -509,15 +499,7 @@ public class UserServiceImpl implements UserService {
 		}
 
 		// 평가 생성 및 targetUser의 ratings에 추가
-		UserRating userRating = new UserRating(
-			reviewerId,
-			targetUserId,
-			request.meetingId(),
-			request.ratingScore()
-		);
-
-		// User 애그리거트를 통해 평가 추가
-		targetUser.getRatings().add(userRating);
+		targetUser.addRating(reviewerId, request.meetingId(), request.ratingScore());
 
 		recalculateUserScore(targetUserId);
 	}

--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -37,6 +37,7 @@ import com.example.momo.global.webclient.meeting.MeetingClient;
 import com.example.momo.global.webclient.meeting.dto.MeetingClientResponseDto;
 import com.example.momo.global.webclient.meeting.dto.ParticipantClientResponseDto;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,6 +60,7 @@ public class UserServiceImpl implements UserService {
 	private final MeetingClient meetingClient;
 	private final UserOutboxService userOutboxService;
 	private final ApplicationEventPublisher eventPublisher;
+	private final EntityManager entityManager;
 
 	// ==================== 1. 회원 관리 ====================
 
@@ -255,6 +257,9 @@ public class UserServiceImpl implements UserService {
 
 		// 3. 카테고리 업데이트
 		user.updateCategories(categoryIds);
+
+		// 4. 영속성 컨텍스트 플러시
+		entityManager.flush();
 
 		log.info("관심 카테고리 수정 완료: userId={}, 이전={}, 변경후={}",
 			userId, oldCategoryIds, categoryIds);

--- a/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/user/application/UserServiceImpl.java
@@ -258,9 +258,6 @@ public class UserServiceImpl implements UserService {
 		// 3. 카테고리 업데이트
 		user.updateCategories(categoryIds);
 
-		// 4. 영속성 컨텍스트 플러시
-		entityManager.flush();
-
 		log.info("관심 카테고리 수정 완료: userId={}, 이전={}, 변경후={}",
 			userId, oldCategoryIds, categoryIds);
 
@@ -353,7 +350,7 @@ public class UserServiceImpl implements UserService {
 
 		// 3. 중복 팔로우 확인
 		boolean alreadyFollowing = follower.getFollowings().stream()
-			.anyMatch(follow -> follow.getFollowingId().equals(followingId));
+			.anyMatch(follow -> follow.getFollowing().getId().equals(followingId));
 
 		if (alreadyFollowing) {
 			log.info("이미 팔로우 중: followerId={}, followingId={}", followerId, followingId);
@@ -361,8 +358,8 @@ public class UserServiceImpl implements UserService {
 		}
 
 		// 4. 팔로우 관계 생성 및 카운트 증가
-		follower.addFollowing(followingId);        // 팔로잉 추가 + 카운트 증가
-		following.increaseFollowerCount();         // 팔로워 카운트만 증가
+		follower.addFollowing(following);        // User 엔티티로 전달
+		following.increaseFollowerCount();       // 팔로워 카운트만 증가
 
 		// 5. 아웃박스 이벤트 저장
 		userOutboxService.saveUserFollowedEvent(
@@ -400,7 +397,7 @@ public class UserServiceImpl implements UserService {
 
 		// 3. 팔로우 관계 존재 확인
 		boolean isFollowing = follower.getFollowings().stream()
-			.anyMatch(follow -> follow.getFollowingId().equals(followingId));
+			.anyMatch(follow -> follow.getFollowing().getId().equals(followingId));
 
 		if (!isFollowing) {
 			log.info("팔로우하지 않은 사용자: followerId={}, followingId={}", followerId, followingId);
@@ -408,8 +405,8 @@ public class UserServiceImpl implements UserService {
 		}
 
 		// 4. 팔로우 관계 삭제 및 카운트 감소
-		follower.removeFollowing(followingId);     // 팔로잉 제거 + 카운트 감소
-		following.decreaseFollowerCount();         // 팔로워 카운트만 감소
+		follower.removeFollowing(following);     // User 엔티티로 전달
+		following.decreaseFollowerCount();       // 팔로워 카운트만 감소
 
 		log.info("언팔로우 완료: followerId={}, followingId={}", followerId, followingId);
 	}

--- a/src/main/java/com/example/momo/domain/user/domain/User.java
+++ b/src/main/java/com/example/momo/domain/user/domain/User.java
@@ -54,13 +54,11 @@ public class User extends BaseEntity {
 	private Double longitude;
 
 	// === 연관관계 (OneToMany 단방향) ===
-	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id")
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
 	private List<UserCategory> categories = new ArrayList<>();
 
 	// 내가 팔로잉을 하는 사람들의 리스트
-	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, fetch = FetchType.LAZY)
-	@JoinColumn(name = "follower_id")
+	@OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
 	private List<UserFollow> followings = new ArrayList<>();
 
 	// 내가 받은 평가들
@@ -98,14 +96,15 @@ public class User extends BaseEntity {
 		this.ratings.add(rating);
 	}
 
-	public void addFollowing(Long followingId) {
-		UserFollow userFollow = new UserFollow(this.id, followingId);
+	public void addFollowing(User following) {
+		UserFollow userFollow = new UserFollow(this, following);
 		this.followings.add(userFollow);
 		this.incrementFollowingCount();
 	}
 
-	public void removeFollowing(Long followingId) {
-		this.followings.removeIf(follow -> follow.getFollowingId().equals(followingId));
+	public void removeFollowing(User following) {
+		this.followings.removeIf(follow ->
+			follow.getFollowing().getId().equals(following.getId()));
 		this.decrementFollowingCount();
 	}
 
@@ -129,7 +128,7 @@ public class User extends BaseEntity {
 		this.categories.clear();
 		if (categoryIds != null && !categoryIds.isEmpty()) {
 			for (Integer categoryId : categoryIds) {
-				UserCategory category = new UserCategory(this.id, categoryId);
+				UserCategory category = new UserCategory(this, categoryId);
 				this.categories.add(category);
 			}
 		}

--- a/src/main/java/com/example/momo/domain/user/domain/User.java
+++ b/src/main/java/com/example/momo/domain/user/domain/User.java
@@ -59,7 +59,7 @@ public class User extends BaseEntity {
 	private List<UserCategory> categories = new ArrayList<>();
 
 	// 내가 팔로잉을 하는 사람들의 리스트
-	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
+	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, fetch = FetchType.LAZY)
 	@JoinColumn(name = "follower_id")
 	private List<UserFollow> followings = new ArrayList<>();
 

--- a/src/main/java/com/example/momo/domain/user/domain/User.java
+++ b/src/main/java/com/example/momo/domain/user/domain/User.java
@@ -91,6 +91,50 @@ public class User extends BaseEntity {
 		return user;
 	}
 
+	// === 하위 엔티티 관리 메서드 (User 애그리거트 책임) ===
+
+	public void addRating(Long reviewerId, Long meetingId, Integer ratingScore) {
+		UserRating rating = new UserRating(reviewerId, this.id, meetingId, ratingScore);
+		this.ratings.add(rating);
+	}
+
+	public void addFollowing(Long followingId) {
+		UserFollow userFollow = new UserFollow(this.id, followingId);
+		this.followings.add(userFollow);
+		this.incrementFollowingCount();
+	}
+
+	public void removeFollowing(Long followingId) {
+		this.followings.removeIf(follow -> follow.getFollowingId().equals(followingId));
+		this.decrementFollowingCount();
+	}
+
+	public void increaseFollowerCount() {
+		this.followerCount++;
+	}
+
+	public void decreaseFollowerCount() {
+		this.followerCount--;
+	}
+
+	public void incrementFollowingCount() {
+		this.followingCount++;
+	}
+
+	public void decrementFollowingCount() {
+		this.followingCount--;
+	}
+
+	public void updateCategories(List<Integer> categoryIds) {
+		this.categories.clear();
+		if (categoryIds != null && !categoryIds.isEmpty()) {
+			for (Integer categoryId : categoryIds) {
+				UserCategory category = new UserCategory(this.id, categoryId);
+				this.categories.add(category);
+			}
+		}
+	}
+
 	// === 업데이트 메서드들 ===
 	public void updateNickname(String nickname) {
 		this.nickname = nickname;
@@ -104,31 +148,8 @@ public class User extends BaseEntity {
 		this.score = score;
 	}
 
-	public void incrementFollowingCount() {
-		this.followingCount++;
-	}
-
-	public void decrementFollowingCount() {
-		this.followingCount--;
-	}
-
-	public void incrementFollowerCount() {
-		this.followerCount++;
-	}
-
-	public void decrementFollowerCount() {
-		this.followerCount--;
-	}
-
 	public void updateLocation(Double latitude, Double longitude) {
 		this.latitude = latitude;
 		this.longitude = longitude;
-	}
-
-	public void updateCategories(List<Integer> categoryIds) {
-		this.categories.clear();
-		categoryIds.forEach(categoryId ->
-			this.categories.add(new UserCategory(this.id, categoryId))  // userId 전달
-		);
 	}
 }

--- a/src/main/java/com/example/momo/domain/user/domain/User.java
+++ b/src/main/java/com/example/momo/domain/user/domain/User.java
@@ -53,15 +53,13 @@ public class User extends BaseEntity {
 	@Column(name = "longitude")
 	private Double longitude;
 
-	// === 연관관계 (OneToMany 단방향) ===
+	// === 연관관계 (양방향) ===
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
 	private List<UserCategory> categories = new ArrayList<>();
 
-	// 내가 팔로잉을 하는 사람들의 리스트
 	@OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
 	private List<UserFollow> followings = new ArrayList<>();
 
-	// 내가 받은 평가들
 	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
 	@JoinColumn(name = "target_user_id")
 	private List<UserRating> ratings = new ArrayList<>();
@@ -134,7 +132,7 @@ public class User extends BaseEntity {
 		}
 	}
 
-	// === 업데이트 메서드들 ===
+	// === User 테이블 업데이트 메서드 ===
 	public void updateNickname(String nickname) {
 		this.nickname = nickname;
 	}

--- a/src/main/java/com/example/momo/domain/user/domain/User.java
+++ b/src/main/java/com/example/momo/domain/user/domain/User.java
@@ -54,7 +54,7 @@ public class User extends BaseEntity {
 	private Double longitude;
 
 	// === 연관관계 (OneToMany 단방향) ===
-	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
+	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private List<UserCategory> categories = new ArrayList<>();
 

--- a/src/main/java/com/example/momo/domain/user/domain/UserCategory.java
+++ b/src/main/java/com/example/momo/domain/user/domain/UserCategory.java
@@ -26,7 +26,7 @@ public class UserCategory {
 	@Column(name = "category_id", nullable = false)
 	private Integer categoryId;
 
-	public UserCategory(Long userId, Integer categoryId) {
+	UserCategory(Long userId, Integer categoryId) {
 		this.userId = userId;
 		this.categoryId = categoryId;
 	}

--- a/src/main/java/com/example/momo/domain/user/domain/UserCategory.java
+++ b/src/main/java/com/example/momo/domain/user/domain/UserCategory.java
@@ -2,9 +2,12 @@ package com.example.momo.domain.user.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,14 +23,15 @@ public class UserCategory {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "user_id", nullable = false)
-	private Long userId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
 
 	@Column(name = "category_id", nullable = false)
 	private Integer categoryId;
 
-	UserCategory(Long userId, Integer categoryId) {
-		this.userId = userId;
+	UserCategory(User user, Integer categoryId) {
+		this.user = user;
 		this.categoryId = categoryId;
 	}
 }

--- a/src/main/java/com/example/momo/domain/user/domain/UserFollow.java
+++ b/src/main/java/com/example/momo/domain/user/domain/UserFollow.java
@@ -28,7 +28,7 @@ public class UserFollow extends BaseCreateEntity {
 	@Column(nullable = false, name = "following_id")
 	private Long followingId;
 
-	public UserFollow(Long followerId, Long followingId) {
+	UserFollow(Long followerId, Long followingId) {
 		this.followerId = followerId;
 		this.followingId = followingId;
 	}

--- a/src/main/java/com/example/momo/domain/user/domain/UserFollow.java
+++ b/src/main/java/com/example/momo/domain/user/domain/UserFollow.java
@@ -2,11 +2,13 @@ package com.example.momo.domain.user.domain;
 
 import com.example.momo.global.common.entity.BaseCreateEntity;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,14 +24,16 @@ public class UserFollow extends BaseCreateEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, name = "follower_id")
-	private Long followerId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "follower_id", nullable = false)
+	private User follower;  // 팔로우 하는 사람
 
-	@Column(nullable = false, name = "following_id")
-	private Long followingId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "following_id", nullable = false)
+	private User following; // 팔로우 받는 사람
 
-	UserFollow(Long followerId, Long followingId) {
-		this.followerId = followerId;
-		this.followingId = followingId;
+	UserFollow(User follower, User following) {
+		this.follower = follower;
+		this.following = following;
 	}
 }

--- a/src/main/java/com/example/momo/domain/user/domain/UserRating.java
+++ b/src/main/java/com/example/momo/domain/user/domain/UserRating.java
@@ -34,7 +34,7 @@ public class UserRating extends BaseCreateEntity {
 	@Column(nullable = false, name = "rating_score")
 	private Integer ratingScore;
 
-	public UserRating(Long reviewerId, Long targetUserId, Long meetingId, Integer ratingScore) {
+	UserRating(Long reviewerId, Long targetUserId, Long meetingId, Integer ratingScore) {
 		this.reviewerId = reviewerId;
 		this.targetUserId = targetUserId;
 		this.meetingId = meetingId;

--- a/src/main/java/com/example/momo/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/example/momo/domain/user/domain/UserRepository.java
@@ -43,8 +43,6 @@ public interface UserRepository {
 
 	Slice<User> findFollowersByUserId(Long userId, Pageable pageable);
 
-	int deleteUserFollow(Long followerId, Long followingId);
-
 	// ==================== 사용자 저장 및 단일 조회 ====================
 
 	void save(User user);

--- a/src/main/java/com/example/momo/domain/user/event/rabbitmq/producer/UserEventProducer.java
+++ b/src/main/java/com/example/momo/domain/user/event/rabbitmq/producer/UserEventProducer.java
@@ -41,7 +41,7 @@ public class UserEventProducer {
 
 		String correlationId = "user-withdrawn-" + userId;
 
-		publishEvent(eventWrapper, RoutingKeys.USER_WITHDRAWN, correlationId);
+		publishEvent(eventWrapper, RoutingKeys.USER_WITHDRAWN_KEY, correlationId);
 	}
 
 	/**
@@ -63,7 +63,7 @@ public class UserEventProducer {
 
 		String correlationId = "user-followed-" + followerId + "-" + followingId;
 
-		publishEvent(eventWrapper, RoutingKeys.USER_FOLLOWED, correlationId);
+		publishEvent(eventWrapper, RoutingKeys.USER_FOLLOWED_KEY, correlationId);
 	}
 
 	/**

--- a/src/main/java/com/example/momo/domain/user/event/rabbitmq/producer/UserEventProducer.java
+++ b/src/main/java/com/example/momo/domain/user/event/rabbitmq/producer/UserEventProducer.java
@@ -33,10 +33,12 @@ public class UserEventProducer {
 	 */
 	public void publishUserWithdrawn(Long userId, String email, String nickname) {
 		UserEventMessage.UserWithdrawnData data = new UserEventMessage.UserWithdrawnData(userId, email, nickname);
+
 		EventWrapper<UserEventMessage.UserWithdrawnData> eventWrapper = EventWrapper.of(
 			EventTypeNames.USER_WITHDRAWN,
 			data
 		);
+
 		String correlationId = "user-withdrawn-" + userId;
 
 		publishEvent(eventWrapper, RoutingKeys.USER_WITHDRAWN, correlationId);
@@ -50,12 +52,15 @@ public class UserEventProducer {
 	 * @param followerNickname 팔로우한 사용자 닉네임
 	 */
 	public void publishUserFollowed(Long followerId, Long followingId, String followerNickname) {
-		UserEventMessage.UserFollowedData data = new UserEventMessage.UserFollowedData(followerId, followingId,
-			followerNickname);
+		UserEventMessage.UserFollowedData data =
+			new UserEventMessage.UserFollowedData(followerId, followingId,
+				followerNickname);
+
 		EventWrapper<UserEventMessage.UserFollowedData> eventWrapper = EventWrapper.of(
 			EventTypeNames.USER_FOLLOWED,
 			data
 		);
+
 		String correlationId = "user-followed-" + followerId + "-" + followingId;
 
 		publishEvent(eventWrapper, RoutingKeys.USER_FOLLOWED, correlationId);
@@ -80,6 +85,7 @@ public class UserEventProducer {
 				eventWrapper,
 				correlationData                   // 발행 결과 추적용 ID
 			);
+
 			log.info("[User] 이벤트 발행 요청 완료 - eventType: {}, eventId: {}, correlationId: {}",
 				eventWrapper.type(), eventWrapper.uuId(), correlationId);
 

--- a/src/main/java/com/example/momo/domain/user/event/rabbitmq/producer/UserEventProducer.java
+++ b/src/main/java/com/example/momo/domain/user/event/rabbitmq/producer/UserEventProducer.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import com.example.momo.global.rabbitmq.constant.EventTypeNames;
 import com.example.momo.global.rabbitmq.constant.RabbitExchangeNames;
 import com.example.momo.global.rabbitmq.constant.RoutingKeys;
-import com.example.momo.global.rabbitmq.dto.UserEventMessage;
+import com.example.momo.global.rabbitmq.dto.User.UserEventMessage;
 import com.example.momo.global.rabbitmq.dto.common.EventWrapper;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/example/momo/domain/user/event/rabbitmq/producer/UserEventProducer.java
+++ b/src/main/java/com/example/momo/domain/user/event/rabbitmq/producer/UserEventProducer.java
@@ -83,6 +83,11 @@ public class UserEventProducer {
 				RabbitExchangeNames.USER_EVENTS,  // Exchange: "momo.user.events"
 				routingKey,                       // RoutingKey: "user.withdrawn"
 				eventWrapper,
+				message -> {
+					message.getMessageProperties()
+						.setHeader("correlationId", correlationId);
+					return message;
+				},
 				correlationData                   // 발행 결과 추적용 ID
 			);
 

--- a/src/main/java/com/example/momo/domain/user/infra/UserJpaRepository.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserJpaRepository.java
@@ -38,26 +38,26 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 	// ==================== 팔로우 시스템 ====================
 
 	@Query("""
-			SELECT u FROM User u
-			WHERE u.id IN (
-				SELECT uf.followingId
-				FROM UserFollow uf
-				WHERE uf.followerId = :userId
-			)
-			AND u.isDeleted = false
-			ORDER BY u.id
+		    SELECT u FROM User u
+		    WHERE u.id IN (
+		        SELECT uf.following.id
+		        FROM UserFollow uf
+		        WHERE uf.follower.id = :userId
+		    )
+		    AND u.isDeleted = false
+		    ORDER BY u.id
 		""")
 	Slice<User> findFollowingsByUserId(@Param("userId") Long userId, Pageable pageable);
 
 	@Query("""
-			SELECT u FROM User u
-			WHERE u.id IN (
-				SELECT uf.followerId
-				FROM UserFollow uf
-				WHERE uf.followingId = :userId
-			)
-			AND u.isDeleted = false
-			ORDER BY u.id
+		    SELECT u FROM User u
+		    WHERE u.id IN (
+		        SELECT uf.follower.id
+		        FROM UserFollow uf
+		        WHERE uf.following.id = :userId
+		    )
+		    AND u.isDeleted = false
+		    ORDER BY u.id
 		""")
 	Slice<User> findFollowersByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/momo/domain/user/infra/UserJpaRepository.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserJpaRepository.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -61,8 +60,4 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 			ORDER BY u.id
 		""")
 	Slice<User> findFollowersByUserId(@Param("userId") Long userId, Pageable pageable);
-
-	@Modifying
-	@Query("DELETE FROM UserFollow uf WHERE uf.followerId = :followerId AND uf.followingId = :followingId")
-	int deleteUserFollow(@Param("followerId") Long followerId, @Param("followingId") Long followingId);
 }

--- a/src/main/java/com/example/momo/domain/user/infra/UserRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/user/infra/UserRepositoryImpl.java
@@ -79,11 +79,6 @@ public class UserRepositoryImpl implements UserRepository {
 		return userJpaRepository.findFollowersByUserId(userId, pageable);
 	}
 
-	@Override
-	public int deleteUserFollow(Long followerId, Long followingId) {
-		return userJpaRepository.deleteUserFollow(followerId, followingId);
-	}
-
 	// ==================== 저장 ====================
 
 	@Override

--- a/src/main/java/com/example/momo/global/config/WebClientConfig.java
+++ b/src/main/java/com/example/momo/global/config/WebClientConfig.java
@@ -87,7 +87,7 @@ public class WebClientConfig {
 	 */
 	private HttpClient createHttpClient() {
 		ConnectionProvider connectionProvider = ConnectionProvider.builder("internal-pool")
-			.maxConnections(50)                    // 최대 커넥션 수
+			.maxConnections(100)                    // 최대 커넥션 수
 			.maxIdleTime(Duration.ofSeconds(30))   // 유휴 시간
 			.maxLifeTime(Duration.ofMinutes(10))   // 최대 생존 시간
 			.pendingAcquireTimeout(Duration.ofSeconds(10)) // 커넥션 대기 시간

--- a/src/main/java/com/example/momo/global/rabbitmq/constant/RoutingKeys.java
+++ b/src/main/java/com/example/momo/global/rabbitmq/constant/RoutingKeys.java
@@ -2,8 +2,8 @@ package com.example.momo.global.rabbitmq.constant;
 
 public class RoutingKeys {
 	// User 관련 routing key들
-	public static final String USER_WITHDRAWN = "user.withdrawn";
-	public static final String USER_FOLLOWED = "user.followed";
+	public static final String USER_WITHDRAWN_KEY = "user.withdrawn.key";
+	public static final String USER_FOLLOWED_KEY = "user.followed.key";
 
 	// Message Hub 관련 Key
 	public static final String MESSAGE_HUB_ASSEMBLE = "message-hub.assemble";

--- a/src/main/java/com/example/momo/global/rabbitmq/dto/User/UserEventMessage.java
+++ b/src/main/java/com/example/momo/global/rabbitmq/dto/User/UserEventMessage.java
@@ -1,4 +1,4 @@
-package com.example.momo.global.rabbitmq.dto;
+package com.example.momo.global.rabbitmq.dto.User;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/example/momo/global/rabbitmq/dto/follow/FollowAlarmMessages.java
+++ b/src/main/java/com/example/momo/global/rabbitmq/dto/follow/FollowAlarmMessages.java
@@ -22,7 +22,7 @@ public class FollowAlarmMessages {
 	 * @param followerId 팔로우한 유저 ID
 	 * @param followerUserNickname 팔로우한 유저 닉네임
 	 */
-	@JsonTypeName(EventTypeNames.FOLLOWED)
+	@JsonTypeName(EventTypeNames.USER_FOLLOWED)
 	public record Followed(
 		Long followedId,
 		Long followerId,


### PR DESCRIPTION
## 변경 사항

### 1. 사용자 점수 계산 로직 개선 (fix)
- **신규 사용자 예외 처리**: 평가/참가 이력이 없는 사용자에 대한 기본 점수 제공
- **실제 출석 데이터 활용**: MeetingClient의 `isAttendanceStatus()` 를 통한 정확한 참석률 계산
- **코드 품질 개선**: 불필요한 try-catch 제거, unused variable 정리, 안전장치 강화

### 2. User 도메인 애그리거트 패턴 적용 (refactor)
- **생성자 접근 제한**: User 생성자를 private으로, 하위 엔티티는 package-private으로 제한
- **팩토리 메서드 도입**: `User.create()` 등 명시적 생성 방법 제공
- **애그리거트 책임 강화**: User가 하위 엔티티(UserRating, UserFollow, UserCategory) 생성/관리 담당
- **도메인 로직 캡슐화**: 비즈니스 규칙 검증을 애그리거트 내부로 이동

### 3. JPA 단방향 일대다 관계 문제 해결 (fix)

- **양방향 관계 전환**: UserCategory, UserFollow 엔티티를 양방향 관계로 변경하여 Hibernate NULL UPDATE 문제 근본 해결
- **영속성 문제 완전 해결**: Column 'user_id' cannot be null 에러 발생 원인인 단방향 관계의 구조적 한계 해결
- **효율적인 SQL 생성**: 불필요한 UPDATE → DELETE 과정을 직접적인 DELETE → INSERT로 최적화
### 4. RabbitMQ 이벤트 처리 개선 (feature)
- **correlationId 전체 플로우 구현, Auth 도메인 예외 처리 강화, 장애 추적 및 모니터링 개선**

## 점수 계산 알고리즘

### 점수 구성 (총 100점)
- **평점 점수 (60%)**: 사용자 평가 평균 기반
- **참석률 점수 (30%)**: 실제 출석 데이터 기반 계산  
- **활동도 점수 (10%)**: 최근 3개월 참가 횟수 기준

### 신규 사용자 처리
```java
// 평가 없는 사용자: 30점 (2.5/5.0 * 60)
// 참가 이력 없는 사용자: 15점 (50% 참석률)
// 최근 활동 없는 사용자: 0점
```

## 애그리거트 패턴 적용 및 캡슐화

### Before
```java
// 서비스에서 직접 엔티티 생성
UserRating rating = new UserRating(reviewerId, meetingId, score);
targetUser.getRatings().add(rating);
```

### After  
```java
// 애그리거트에서 생성/관리
targetUser.addRating(reviewerId, meetingId, ratingScore);
```

## JPA 단방향 일대다 관계 문제 해결 방법

해결 방법 :  양방향 관계 
```java
// User.java - 관계 소유권을 UserCategory에 위임
@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
private List<UserCategory> categories;

// UserCategory.java - 관계의 실제 소유자
@ManyToOne(fetch = FetchType.LAZY)
@JoinColumn(name = "user_id", nullable = false)
private User user;

// 결과: 직접적인 DELETE → INSERT 실행으로 NULL UPDATE 단계 제거
```

## RabbitMQ correlationId 플로우

### 발행 측

```java// 헤더에 correlationId 포함
userRabbitTemplate.convertAndSend(exchange, routingKey, eventWrapper,
    message -> {
        message.getMessageProperties().setHeader("correlationId", correlationId);
        return message;
    });
```
### 수신 측

```java// correlationId 수신 및 모든 로그에 포함
@RabbitHandler
public void handleUserEvent(EventWrapper<?> eventWrapper,
                           @Header("correlationId") String correlationId)
```
## 추후 개선 사항

- Flyway `clean-disabled: true` 설정은 목요일~금요일 배포 시 적용 예정
- 현재 WebClient, JPA, HikariCP 설정은 프로덕션 레벨로 최적화 완료
- 추후 Meeting API에서 배치 출석 정보 제공 시 N+1 문제 해결 예정 : 급한 사항은 아닙니다. 기능 자체는 돌아갈거같습니다. 그래도 혹시 몰라서 UserServiceImpl.java 에서 TODO로 체크해놨습니다.