### PR TITLE
feat(payment): participant 이벤트를 EventWrapper로 수신, DLQ 정책 정비

### DIFF
--- a/src/main/java/com/example/momo/domain/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/payment/application/PaymentServiceImpl.java
@@ -63,51 +63,43 @@ public class PaymentServiceImpl implements PaymentService {
 	 * PENDING 결제가 있으면 재사용, 없으면 새로 생성
 	 */
 	@Override
+	@Transactional(noRollbackFor = PaymentException.class)
 	public PaymentResponseDto createTestKeyInPayment(CardPaymentTestRequestDto request, Long userId) {
-		// 1. 테스트 환경 검증
-		validateTestKey();
-
-		// 2. 엔티티 조회
-		MeetingClientResponseDto meeting = getMeetingViaClient(request.getMeetingId());
-		UserClientResponseDto user = getUserViaClient(userId);
-		int amount = meeting.getParticipationFee();
-
-		// 3. 기존 결제 상태 확인
-		// 3-1. 이미 완료된 결제가 있으면 예외
-		if (paymentRepository.existsByMeetingIdAndUserIdAndStatus(
-			meeting.getId(), user.getId(), PaymentStatus.COMPLETED)) {
-			throw new PaymentException(PaymentErrorCode.ALREADY_PAID);
-		}
-
-		// 3-2. PENDING 또는 FAILED 결제 조회
-		Payment payment = paymentRepository.findByMeetingIdAndUserId(
-				meeting.getId(), user.getId())
-			.filter(p -> p.getStatus() == PaymentStatus.PENDING || p.getStatus() == PaymentStatus.FAILED)
-			.orElseGet(() -> {
-				// PENDING이 없으면 새로 생성 (예외 케이스 대비)
-				Payment newPayment = Payment.createPending(user.getId(), meeting.getId(),
-					amount);
-				return paymentRepository.save(newPayment);
-			});
-
-		// FAILED 상태인 경우 PENDING으로 변경
-		if (payment.getStatus() == PaymentStatus.FAILED) {
-			payment = Payment.createPending(userId, meeting.getId(), amount);
-			payment = paymentRepository.save(payment);
-		}
-
-		// 4. 무료 모임인 경우 결제 차단
-		if (amount == 0) {
-			log.warn("무료 모임에 대한 결제 요청이 차단되었습니다. meetingId: {}, userId: {}",
-				meeting.getId(), user.getId());
-			throw new PaymentException(PaymentErrorCode.FREE_MEETING_PARTICIPATION_FAILED);
-		}
-
-		// 5. 유료 결제 처리
-		String orderId = "order-" + UUID.randomUUID();
+		Long meetingId = request.getMeetingId();
+		Payment payment = null;
 
 		try {
-			// Key-in API 호출
+			// 1) 사전 검증
+			validateTestKey();
+
+			// 2) 조회
+			MeetingClientResponseDto meeting = getMeetingViaClient(meetingId);
+			UserClientResponseDto user = getUserViaClient(userId);
+			int amount = meeting.getParticipationFee();
+
+			// 3) 이미 결제 완료 멱등 체크
+			if (paymentRepository.existsByMeetingIdAndUserIdAndStatus(
+				meeting.getId(), user.getId(), PaymentStatus.COMPLETED)) {
+				throw new PaymentException(PaymentErrorCode.ALREADY_PAID);
+			}
+
+			// 4) PENDING/FAILED 결제 재사용(또는 생성)
+			payment = paymentRepository.findByMeetingIdAndUserId(meeting.getId(), user.getId())
+				.filter(p -> p.getStatus() == PaymentStatus.PENDING || p.getStatus() == PaymentStatus.FAILED)
+				.orElseGet(() -> paymentRepository.save(
+					Payment.createPending(user.getId(), meeting.getId(), amount)));
+
+			if (payment.getStatus() == PaymentStatus.FAILED) {
+				payment = paymentRepository.save(Payment.createPending(userId, meeting.getId(), amount));
+			}
+
+			// 5) 무료 모임 차단
+			if (amount == 0) {
+				throw new PaymentException(PaymentErrorCode.FREE_MEETING_PARTICIPATION_FAILED);
+			}
+
+			// 6) 결제 수행
+			String orderId = "order-" + UUID.randomUUID();
 			TossKeyInRequestDto tossRequest = buildKeyInRequest(request, meeting, amount, orderId);
 			TossPaymentResponseDto result = paymentClient.createTestKeyInPayment(tossRequest, orderId);
 
@@ -115,39 +107,37 @@ public class PaymentServiceImpl implements PaymentService {
 				throw new PaymentException(PaymentErrorCode.TOSS_CONFIRM_FAILED);
 			}
 
-			// 결제 완료 처리
+			// 7) 완료 처리 + 성공 이벤트
 			LocalDateTime approvedAt = OffsetDateTime.parse(result.getApprovedAt()).toLocalDateTime();
 			payment.complete(result.getPaymentKey(), orderId, approvedAt);
 
-			// Outbox 저장 및 도메인 이벤트 발행
 			Long outboxId = saveOutboxEvent(payment, "PAYMENT_COMPLETED", RoutingKeys.PAYMENT_COMPLETED_KEY);
-
 			eventPublisher.publishEvent(new PaymentEvents.Completed(
-				payment.getId(),
-				payment.getUserId(),
-				payment.getMeetingId(),
-				payment.getAmount(),
-				orderId,
-				outboxId
-			));
+				payment.getId(), payment.getUserId(), payment.getMeetingId(), payment.getAmount(), orderId, outboxId));
 
 			log.info("결제 완료 - paymentId: {}, orderId: {}", payment.getId(), orderId);
 			return PaymentResponseDto.from(payment);
 
-		} catch (Exception e) {
-			// 결제 실패 처리
-			payment.fail(e.getMessage());
-
-			// Outbox 저장 및 도메인 이벤트 발행
-			Long outboxId = saveOutboxEvent(payment, "PAYMENT_FAILED", RoutingKeys.PAYMENT_FAILED_KEY);
+		} catch (PaymentException pe) {
+			// 비즈니스 예외도 '실패 이벤트' 발행
+			if (payment != null && payment.getStatus() != PaymentStatus.FAILED) {
+				payment.fail(pe.getMessage());
+			}
+			Long outboxId = saveFailedOutboxEvent(
+				payment != null ? payment.getId() : null, meetingId, userId, pe.getMessage());
 			eventPublisher.publishEvent(new PaymentEvents.Failed(
-				payment.getId(),
-				payment.getUserId(),
-				payment.getMeetingId(),
-				e.getMessage(),
-				outboxId
-			));
+				payment != null ? payment.getId() : null, userId, meetingId, pe.getMessage(), outboxId));
+			throw pe; // 그대로 전파ㅂㅂ
 
+		} catch (Exception e) {
+			// 시스템/외부 예외도 '실패 이벤트' 발행
+			if (payment != null && payment.getStatus() != PaymentStatus.FAILED) {
+				payment.fail(e.getMessage());
+			}
+			Long outboxId = saveFailedOutboxEvent(
+				payment != null ? payment.getId() : null, meetingId, userId, e.getMessage());
+			eventPublisher.publishEvent(new PaymentEvents.Failed(
+				payment != null ? payment.getId() : null, userId, meetingId, e.getMessage(), outboxId));
 			throw new PaymentException(PaymentErrorCode.TOSS_CONFIRM_FAILED);
 		}
 	}
@@ -158,53 +148,76 @@ public class PaymentServiceImpl implements PaymentService {
 	 * 결제 환불 처리 - 환불 후 재결제가 가능하도록 레코드 삭제
 	 */
 	@Override
+	@Transactional(noRollbackFor = PaymentException.class)
 	public PaymentResponseDto refundPayment(Long paymentId, Long userId, RefundRequestDto request) {
-		Payment payment = paymentRepository.findById(paymentId)
-			.orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+		Payment payment = null;
 
-		if (!payment.getUserId().equals(userId)) {
-			throw new PaymentException(PaymentErrorCode.UNAUTHORIZED_REFUND);
-		}
+		try {
 
-		// 환불 가능 상태 확인
-		if (payment.getStatus() != PaymentStatus.COMPLETED) {
-			throw new PaymentException(PaymentErrorCode.REFUND_NOT_ALLOWED);
-		}
+			payment = paymentRepository.findById(paymentId)
+				.orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
-		// 토스 환불 처리
-		if ("TOSS".equalsIgnoreCase(payment.getPaymentMethod())) {
-			try {
-				paymentClient.cancelPayment(payment.getPgTransactionId(), request.getReason());
-			} catch (HttpClientErrorException e) {
-				log.error("[TOSS] 환불 실패: {}", e.getResponseBodyAsString());
-				throw new PaymentException(PaymentErrorCode.REFUND_FAILED);
+			if (!payment.getUserId().equals(userId)) {
+				throw new PaymentException(PaymentErrorCode.UNAUTHORIZED_REFUND);
 			}
+
+			// 환불 가능 상태 확인
+			if (payment.getStatus() != PaymentStatus.COMPLETED) {
+				throw new PaymentException(PaymentErrorCode.REFUND_NOT_ALLOWED);
+			}
+
+			// 토스 환불 처리
+			if ("TOSS".equalsIgnoreCase(payment.getPaymentMethod())) {
+				try {
+					paymentClient.cancelPayment(payment.getPgTransactionId(), request.getReason());
+				} catch (HttpClientErrorException e) {
+					log.error("[TOSS] 환불 실패: {}", e.getResponseBodyAsString());
+					throw new PaymentException(PaymentErrorCode.REFUND_FAILED);
+				}
+			}
+
+			// 환불 상태로 변경
+			payment.refund();
+
+			// 환불 응답 생성
+			PaymentResponseDto response = PaymentResponseDto.from(payment);
+
+			// Outbox 저장 및 도메인 이벤트 발행
+			Long outboxId = saveOutboxEvent(payment, "PAYMENT_REFUNDED", RoutingKeys.PAYMENT_REFUNDED_KEY,
+				request.getReason());
+			eventPublisher.publishEvent(new PaymentEvents.Refunded(
+				payment.getId(),
+				payment.getUserId(),
+				payment.getMeetingId(),
+				payment.getAmount(),
+				request.getReason(),
+				outboxId
+			));
+
+			// 결제 레코드 삭제 (재결제 가능하도록)
+			paymentRepository.delete(payment);
+
+			return response;
+		} catch (PaymentException pe) {
+			log.warn("[환불 실패-비즈니스] paymentId={}, userId={}, msg={}",
+				payment != null ? payment.getId() : null, userId, pe.getMessage());
+			recordRefundFailure(payment, payment != null ? payment.getMeetingId() : null, pe.getMessage());
+			throw pe;
+			
+		} catch (Exception e) {
+			log.error("[환불 실패-시스템] paymentId={}, userId={}, err={}",
+				payment != null ? payment.getId() : null, userId, e.getMessage(), e);
+			recordRefundFailure(payment, payment != null ? payment.getMeetingId() : null, e.getMessage());
+			throw new PaymentException(PaymentErrorCode.REFUND_FAILED);
+
 		}
-
-		// 환불 상태로 변경
-		payment.refund();
-
-		// 환불 응답 생성
-		PaymentResponseDto response = PaymentResponseDto.from(payment);
-
-		// Outbox 저장 및 도메인 이벤트 발행
-		Long outboxId = saveOutboxEvent(payment, "PAYMENT_REFUNDED", RoutingKeys.PAYMENT_REFUNDED_KEY);
-		eventPublisher.publishEvent(new PaymentEvents.Refunded(
-			payment.getId(),
-			payment.getUserId(),
-			payment.getMeetingId(),
-			payment.getAmount(),
-			request.getReason(),
-			outboxId
-		));
-
-		// 결제 레코드 삭제 (재결제 가능하도록)
-		paymentRepository.delete(payment);
-
-		return response;
 	}
 
 	private Long saveOutboxEvent(Payment payment, String eventType, String routingKey) {
+		return saveOutboxEvent(payment, eventType, routingKey, null);
+	}
+
+	private Long saveOutboxEvent(Payment payment, String eventType, String routingKey, String refundReason) {
 		try {
 			Object eventMessage;
 			// 1) 이벤트 DTO 구성 (outboxId는 헤더로 보내므로 DTO 필드는 null로 둬도 됨)
@@ -223,7 +236,7 @@ public class PaymentServiceImpl implements PaymentService {
 				case "PAYMENT_REFUNDED" -> eventMessage = new PaymentEventMessages.Refunded(
 					payment.getId(), payment.getUserId(), payment.getMeetingId(),
 					payment.getAmount(),
-					"환불 사유", // 필요 시 실제 사유로 교체
+					(refundReason != null && !refundReason.isBlank()) ? refundReason : "사유 미기재",
 					null
 				);
 				default -> throw new IllegalArgumentException("Unknown event type: " + eventType);
@@ -255,6 +268,35 @@ public class PaymentServiceImpl implements PaymentService {
 			return saved.getId();
 		} catch (Exception e) {
 			log.error("Outbox 저장 실패", e);
+			throw new RuntimeException("이벤트 저장 실패", e);
+		}
+	}
+
+	private Long saveFailedOutboxEvent(Long paymentId, Long meetingId, Long userId, String reason) {
+		try {
+			PaymentEventMessages.Failed msg = new PaymentEventMessages.Failed(
+				paymentId, userId, meetingId, (reason != null ? reason : "결제 실패"), null
+			);
+
+			EventWrapper<Object> wrapper = EventWrapper.of(EventTypeNames.PAYMENT_FAILED, msg);
+			String payload = objectMapper.writeValueAsString(wrapper);
+
+			// Payment 엔티티가 없을 수 있으니, aggregateId를 안전하게 구성
+			String aggregateId = (paymentId != null)
+				? String.valueOf(paymentId)
+				: String.format("meeting:%s/user:%s", String.valueOf(meetingId), String.valueOf(userId));
+
+			PaymentOutbox outbox = PaymentOutbox.create(
+				"PAYMENT_FAILED",
+				aggregateId,
+				RoutingKeys.PAYMENT_FAILED_KEY,
+				payload
+			);
+			PaymentOutbox saved = outboxRepository.save(outbox);
+			log.debug("Outbox 실패 이벤트 저장 - aggregateId: {}", aggregateId);
+			return saved.getId();
+		} catch (Exception e) {
+			log.error("Outbox 실패 이벤트 저장 실패", e);
 			throw new RuntimeException("이벤트 저장 실패", e);
 		}
 	}
@@ -382,5 +424,14 @@ public class PaymentServiceImpl implements PaymentService {
 			.customerEmail("test@example.com")
 			.customerName("테스트")
 			.build();
+	}
+
+	private void recordRefundFailure(Payment payment, Long meetingId, String errorMessage) {
+		Long paymentId = (payment != null ? payment.getId() : null);
+		Long userId = (payment != null ? payment.getUserId() : null);
+
+		// TODO: 필요 시 RefundFailureRecord 저장 로직으로 대체
+		log.error("[환불 실패 기록] paymentId={}, meetingId={}, userId={}, error={}",
+			paymentId, meetingId, userId, errorMessage);
 	}
 }

--- a/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
+++ b/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
@@ -86,14 +86,6 @@ public class PaymentEventConsumer {
 				throw new AmqpRejectAndDontRequeueException("[register] missing fields");
 			}
 
-			// 멱등: 이미 결제완료 -> ACK
-			if (paymentRepository.existsByMeetingIdAndUserIdAndStatus(
-				meetingId, userId, PaymentStatus.COMPLETED)) {
-				log.info("[register] already completed. meetingId={}, userId={}", meetingId, userId);
-				ch.basicAck(tag, false);
-				return;
-			}
-
 			// 결제 비즈니스
 			log.info("[결제 시작] meetingId={}, userId={}", meetingId, userId);
 			CardPaymentTestRequestDto req = CardPaymentTestRequestDto.builder()

--- a/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
+++ b/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
@@ -1,10 +1,11 @@
 package com.example.momo.domain.payment.event.rabbitmq.consumer;
 
+import static com.example.momo.global.rabbitmq.constant.EventTypeNames.*;
 import static com.example.momo.global.rabbitmq.constant.QueueNames.*;
 
-import java.io.IOException;
 import java.util.List;
 
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,7 @@ import com.example.momo.domain.payment.application.dto.RefundRequestDto;
 import com.example.momo.domain.payment.domain.Payment;
 import com.example.momo.domain.payment.domain.PaymentRepository;
 import com.example.momo.domain.payment.enums.PaymentStatus;
+import com.example.momo.domain.payment.exception.PaymentException;
 import com.example.momo.global.rabbitmq.dto.common.EventWrapper;
 import com.example.momo.global.rabbitmq.dto.meeting.ParticipantEvents;
 import com.example.momo.global.springEvent.meeting.MeetingMessageEvents;
@@ -28,6 +30,13 @@ import lombok.extern.slf4j.Slf4j;
  * Payment 도메인의 RabbitMQ 이벤트 Consumer
  * - 참가자 등록/취소 이벤트 처리
  * - 모임 삭제 이벤트 처리
+ *
+ * 처리 정책:
+ *  - 성공/멱등: 직접 ACK
+ *  - 비즈니스 예외(PaymentException): ACK (재처리 불필요, 실패 이벤트는 서비스 내부 outbox로 발행)
+ *  - 즉시 DLQ(재시도 불필요): AmqpRejectAndDontRequeueException 던짐
+ *      - NULL, 타입 불일치, 역직렬화 실패, 필수 필드 누락
+ *  - 시스템/일시적 오류: RuntimeException 던짐 -> 컨테이너 재시도 후 DLQ
  */
 @Slf4j
 @Component
@@ -39,232 +48,222 @@ public class PaymentEventConsumer {
 	private final ObjectMapper objectMapper;
 
 	/**
-	 * 1. 참가자 등록 이벤트 처리 - 결제 생성
-	 * Queue: payment.participant.registered.queue
-	 * EventWrapper<ParticipantEvents.Register>를 수신
-	 *
-	 * Meeting에서 참가 신청 시 발행하는 이벤트
-	 * 결제 처리 후 payment.completed 또는 payment.failed 이벤트 발행
+	 * 1) 참가자 등록 -> 결제 생성
 	 */
 	@RabbitListener(
 		queues = PAYMENT_PARTICIPANT_REGISTER,
 		containerFactory = "paymentListenerContainerFactory"
 	)
-	public void handleParticipantRegister(EventWrapper<?> eventWrapper,
-		Channel channel,
-		Message message) {
-		long deliveryTag = message.getMessageProperties().getDeliveryTag();
+	public void handleParticipantRegister(EventWrapper<?> wrapper, Channel ch, Message msg) {
+		long tag = msg.getMessageProperties().getDeliveryTag();
+		Long meetingId = null, userId = null;
 
 		try {
-			// EventWrapper의 data를 ParticipantEvents.Register로 변환
-			ParticipantEvents.Register event = objectMapper.convertValue(
-				eventWrapper.data(),
-				ParticipantEvents.Register.class
-			);
+			// 즉시 DLQ: NULL
+			if (wrapper == null || wrapper.data() == null) {
+				throw new AmqpRejectAndDontRequeueException("[register] null payload");
+			}
 
-			log.info("[결제 시작] 참가자 등록 이벤트 수신 - meetingId: {}, userId: {}",
-				event.meetingId(), event.userId());
+			// 즉시 DLQ: 타입 불일치
+			if (!MEETING_PARTICIPANT_REGISTER.equals(wrapper.type())) {
+				throw new AmqpRejectAndDontRequeueException(
+					"[register] wrong type: " + wrapper.type());
+			}
 
-			// 이미 결제 완료된 경우 체크 (멱등성)
+			// 즉시 DLQ: 역직렬화 실패
+			final ParticipantEvents.Register ev;
+			try {
+				ev = objectMapper.convertValue(wrapper.data(), ParticipantEvents.Register.class);
+			} catch (Exception cvt) {
+				throw new AmqpRejectAndDontRequeueException("[register] deserialize fail", cvt);
+			}
+
+			meetingId = ev.meetingId();
+			userId = ev.userId();
+
+			// 즉시 DLQ: 필수 필드 누락
+			if (meetingId == null || userId == null) {
+				throw new AmqpRejectAndDontRequeueException("[register] missing fields");
+			}
+
+			// 멱등: 이미 결제완료 -> ACK
 			if (paymentRepository.existsByMeetingIdAndUserIdAndStatus(
-				event.meetingId(), event.userId(), PaymentStatus.COMPLETED)) {
-				log.warn("이미 결제 완료됨 – meetingId={}, userId={}",
-					event.meetingId(), event.userId());
-				channel.basicAck(deliveryTag, false);
+				meetingId, userId, PaymentStatus.COMPLETED)) {
+				log.info("[register] already completed. meetingId={}, userId={}", meetingId, userId);
+				ch.basicAck(tag, false);
 				return;
 			}
 
-			// 결제 실행
-			CardPaymentTestRequestDto request = CardPaymentTestRequestDto.builder()
-				.meetingId(event.meetingId())
-				.build();
+			// 결제 비즈니스
+			log.info("[결제 시작] meetingId={}, userId={}", meetingId, userId);
+			CardPaymentTestRequestDto req = CardPaymentTestRequestDto.builder()
+				.meetingId(meetingId).build();
+			paymentService.createTestKeyInPayment(req, userId);
 
-			paymentService.createTestKeyInPayment(request, event.userId());
+			// 성공 -> ACK
+			ch.basicAck(tag, false);
+			log.info("[결제 완료] meetingId={}, userId={}", meetingId, userId);
 
-			channel.basicAck(deliveryTag, false);
-			log.info("[결제 처리 완료] meetingId: {}, userId: {}",
-				event.meetingId(), event.userId());
+		} catch (PaymentException be) {
+			// 비즈니스 예외 -> ACK
+			log.warn("[결제 비즈니스 예외] meetingId={}, userId={}, err={}", meetingId, userId, be.getMessage());
+			safeAck(ch, tag);
+
+		} catch (AmqpRejectAndDontRequeueException reject) {
+			// 즉시 DLQ
+			throw reject;
 
 		} catch (Exception ex) {
-			log.error("[결제 처리 실패] wrapper={}, error={}", eventWrapper, ex.getMessage(), ex);
-			handleMessageFailure(channel, deliveryTag, null, null);
+			// 시스템/일시적 오류 -> 재시도 후 DLQ
+			throw new RuntimeException(ex);
 		}
 	}
 
 	/**
-	 * 2. 참가자 취소 이벤트 처리 - 개별 환불
-	 * Queue: payment.participant.canceled.queue
-	 * EventWrapper<ParticipantEvents.Cancel>을 수신
-	 * (meetingId, userId, hostUserId, participantNickname, refundRequired, amount)
-	 *
-	 * Meeting에서 참가 취소 시 발행하는 이벤트
-	 * 환불 처리 후 payment.refunded 이벤트 발행
+	 * 2) 참가자 취소 -> 개별 환불
 	 */
 	@RabbitListener(
 		queues = PAYMENT_PARTICIPANT_CANCEL,
 		containerFactory = "paymentListenerContainerFactory"
 	)
-	public void handleParticipantCancel(EventWrapper<?> eventWrapper,
-		Channel channel,
-		Message message) {
-		long deliveryTag = message.getMessageProperties().getDeliveryTag();
+	public void handleParticipantCancel(EventWrapper<?> wrapper, Channel ch, Message msg) {
+		long tag = msg.getMessageProperties().getDeliveryTag();
 
 		try {
-			// EventWrapper의 data를 ParticipantEvents.Cancel로 변환
-			ParticipantEvents.Cancel event = objectMapper.convertValue(
-				eventWrapper.data(),
-				ParticipantEvents.Cancel.class
-			);
+			// 즉시 DLQ: NULL
+			if (wrapper == null || wrapper.data() == null) {
+				throw new AmqpRejectAndDontRequeueException("[cancel] null payload");
+			}
 
-			log.info("[환불 시작] 참가자 취소 이벤트 수신 - meetingId: {}, userId: {}, nickname: {}",
-				event.meetingId(), event.userId(), event.participantNickname());
+			// 즉시 DLQ: 타입 불일치
+			if (!MEETING_PARTICIPANT_CANCEL.equals(wrapper.type())) {
+				throw new AmqpRejectAndDontRequeueException("[cancel] wrong type: " + wrapper.type());
+			}
 
-			if (!event.refundRequired()) {
-				log.info("환불 불필요 (무료 모임) - meetingId: {}, userId: {}",
-					event.meetingId(), event.userId());
-				channel.basicAck(deliveryTag, false);
+			// 즉시 DLQ: 역직렬화 실패
+			final ParticipantEvents.Cancel ev;
+			try {
+				ev = objectMapper.convertValue(wrapper.data(), ParticipantEvents.Cancel.class);
+			} catch (Exception cvt) {
+				throw new AmqpRejectAndDontRequeueException("[cancel] deserialize fail", cvt);
+			}
+
+			// 즉시 DLQ: 필수 필드 누락
+			if (ev.meetingId() == null || ev.userId() == null) {
+				throw new AmqpRejectAndDontRequeueException("[cancel] missing fields");
+			}
+
+			log.info("[환불 시작] meetingId={}, userId={}, refundRequired={}",
+				ev.meetingId(), ev.userId(), ev.refundRequired());
+
+			// 무료/환불 불필요 -> ACK
+			if (!ev.refundRequired()) {
+				ch.basicAck(tag, false);
 				return;
 			}
 
-			// 완료된 결제 조회
+			// 완료 결제 조회
 			Payment payment = paymentRepository.findByMeetingIdAndUserIdAndStatus(
-					event.meetingId(), event.userId(), PaymentStatus.COMPLETED)
-				.orElse(null);
+				ev.meetingId(), ev.userId(), PaymentStatus.COMPLETED).orElse(null);
 
+			// 환불할 결제 없음 -> ACK
 			if (payment == null) {
-				log.warn("환불할 결제 내역 없음 - meetingId: {}, userId: {}",
-					event.meetingId(), event.userId());
-				channel.basicAck(deliveryTag, false);
+				log.warn("[환불] no completed payment. meetingId={}, userId={}", ev.meetingId(), ev.userId());
+				ch.basicAck(tag, false);
 				return;
 			}
 
 			// 환불 처리
 			RefundRequestDto refundRequest = new RefundRequestDto(
-				String.format("사용자 %s님의 참가 취소", event.participantNickname())
-			);
+				String.format("사용자 %s님의 참가 취소", ev.participantNickname()));
+			paymentService.refundPayment(payment.getId(), ev.userId(), refundRequest);
 
-			paymentService.refundPayment(payment.getId(), event.userId(), refundRequest);
+			// 성공 -> ACK
+			ch.basicAck(tag, false);
+			log.info("[환불 완료] paymentId={}, amount={}", payment.getId(), payment.getAmount());
 
-			channel.basicAck(deliveryTag, false);
-			log.info("[환불 완료] paymentId: {}, meetingId: {}, userId: {}, amount: {}원",
-				payment.getId(), event.meetingId(), event.userId(), payment.getAmount());
+		} catch (PaymentException be) {
+			// 비즈니스 예외 -> ACK
+			log.warn("[환불 비즈니스 예외] {}", be.getMessage());
+			safeAck(ch, tag);
+
+		} catch (AmqpRejectAndDontRequeueException reject) {
+			// 즉시 DLQ
+			throw reject;
 
 		} catch (Exception ex) {
-			log.error("[환불 실패] wrapper={}, error={}", eventWrapper, ex.getMessage(), ex);
-			handleMessageFailure(channel, deliveryTag, null, null);
+			// 시스템/일시적 오류 -> 재시도 후 DLQ
+			throw new RuntimeException(ex);
 		}
 	}
 
 	/**
-	 * 3. 모임 삭제 이벤트 처리 - 전체 참가자 환불
-	 * Queue: payment.meeting.deleted.queue
-	 * EventWrapper로 수신예정 (아직 모임삭제 쪽에서 반영이 안되어있어서 springevent로 발행되고 있는 상황)
-	 *
-	 * Meeting 삭제 시 발행하는 이벤트
-	 * 모든 참가자의 결제를 환불 처리
+	 * 3) 모임 삭제 -> 전체 환불
 	 */
 	@RabbitListener(
 		queues = PAYMENT_MEETING_DELETED,
 		containerFactory = "paymentListenerContainerFactory"
 	)
-	public void handleMeetingDeleted(MeetingMessageEvents.Delete event,
-		Channel channel,
-		Message message) {
-		long deliveryTag = message.getMessageProperties().getDeliveryTag();
-
-		log.info("[모임 삭제 환불 시작] meetingId: {}, meetingName: {}, 참가자 수: {}명",
-			event.meetingId(), event.meetingName(),
-			event.userIdList() != null ? event.userIdList().size() : 0);
+	public void handleMeetingDeleted(MeetingMessageEvents.Delete event, Channel ch, Message msg) {
+		long tag = msg.getMessageProperties().getDeliveryTag();
 
 		try {
-			// 해당 모임의 모든 완료된 결제 조회
-			List<Payment> completedPayments = paymentRepository
-				.findByMeetingIdAndStatus(event.meetingId(), PaymentStatus.COMPLETED);
+			// 즉시 DLQ: NULL/필수 누락
+			if (event == null || event.meetingId() == null) {
+				throw new AmqpRejectAndDontRequeueException("[meeting.deleted] null event or missing meetingId");
+			}
 
-			if (completedPayments.isEmpty()) {
-				log.info("환불할 결제 내역 없음 - meetingId: {}", event.meetingId());
-				channel.basicAck(deliveryTag, false);
+			log.info("[모임 삭제 환불] meetingId={}, meetingName={}, 참가자={}명",
+				event.meetingId(), event.meetingName(),
+				event.userIdList() != null ? event.userIdList().size() : 0);
+
+			List<Payment> completed = paymentRepository.findByMeetingIdAndStatus(
+				event.meetingId(), PaymentStatus.COMPLETED);
+
+			if (completed.isEmpty()) {
+				ch.basicAck(tag, false);
 				return;
 			}
 
-			log.info("환불 대상: {}건, meetingId: {}",
-				completedPayments.size(), event.meetingId());
-
-			// 환불 처리 결과 추적
-			int successCount = 0;
-			int failCount = 0;
-
-			for (Payment payment : completedPayments) {
+			int ok = 0, fail = 0;
+			for (Payment payment : completed) {
 				try {
-					// 개별 환불 처리
 					RefundRequestDto refundRequest = new RefundRequestDto(
-						String.format("모임 '%s' 삭제로 인한 자동 환불", event.meetingName())
-					);
-
-					paymentService.refundPayment(
-						payment.getId(),
-						payment.getUserId(),
-						refundRequest
-					);
-
-					successCount++;
-					log.info("[환불 성공] paymentId: {}, userId: {}, amount: {}원",
-						payment.getId(), payment.getUserId(), payment.getAmount());
-
+						String.format("모임 '%s' 삭제로 인한 자동 환불", event.meetingName()));
+					paymentService.refundPayment(payment.getId(), payment.getUserId(), refundRequest);
+					ok++;
 				} catch (Exception refundEx) {
-					failCount++;
-					log.error("[환불 실패] paymentId: {}, userId: {}, error: {}",
-						payment.getId(), payment.getUserId(), refundEx.getMessage());
-
-					// 실패 건은 별도 처리 필요 (수동 환불 대상)
+					fail++;
+					log.error("[환불 실패] paymentId={}, err={}", payment.getId(), refundEx.getMessage(), refundEx);
 					recordRefundFailure(payment, event.meetingId(), refundEx.getMessage());
 				}
 			}
 
-			log.info("[모임 삭제 환불 완료] meetingId: {}, 성공: {}건, 실패: {}건",
-				event.meetingId(), successCount, failCount);
+			log.info("[모임 삭제 환불 완료] 성공:{}건, 실패:{}건", ok, fail);
+			// 부분 실패여도 ACK (환불 실패건은 별도 관리)
+			ch.basicAck(tag, false);
 
-			// 일부 실패가 있어도 메시지는 ACK (실패 건은 별도 관리)
-			channel.basicAck(deliveryTag, false);
-
+		} catch (AmqpRejectAndDontRequeueException reject) {
+			throw reject;
 		} catch (Exception ex) {
-			log.error("[모임 삭제 환불 처리 중 예외] meetingId: {}, error: {}",
-				event.meetingId(), ex.getMessage());
-			handleMessageFailure(channel, deliveryTag, event.meetingId(), null);
+			// 시스템/일시적 오류 -> 재시도 후 DLQ
+			throw new RuntimeException(ex);
 		}
 	}
 
-	/**
-	 * 메시지 처리 실패 시 공통 처리
-	 * DLQ로 전송하여 나중에 재처리 가능하도록 함
-	 */
-	private void handleMessageFailure(Channel channel, long deliveryTag,
-		Long meetingId, Long userId) {
-		try {
-			// DLQ로 전송 (requeue=false)
-			channel.basicNack(deliveryTag, false, false);
-			log.warn("메시지를 DLQ로 전송 - meetingId: {}, userId: {}", meetingId, userId);
+	// ===== helpers =====
 
-		} catch (Exception e) {
-			try {
-				// DLQ 전송도 실패하면 재큐잉
-				channel.basicNack(deliveryTag, false, true);
-				log.error("DLQ 전송 실패, 재큐잉 - meetingId: {}, userId: {}", meetingId, userId);
-
-			} catch (IOException io) {
-				log.error("메시지 NACK 실패 - meetingId: {}, userId: {}", meetingId, userId, io);
-			}
-		}
-	}
-
-	/**
-	 * 환불 실패 기록
-	 * TODO: 별도 테이블에 저장하여 관리자가 수동으로 처리할 수 있도록 함
-	 */
 	private void recordRefundFailure(Payment payment, Long meetingId, String errorMessage) {
-		// TODO: RefundFailureRecord 엔티티 생성 및 저장
-		// TODO: 관리자 알림 발송
-		log.error("[환불 실패 기록] paymentId: {}, meetingId: {}, userId: {}, error: {}",
+		// TODO: RefundFailureRecord 엔티티 저장 및 관리자 알림
+		log.error("[환불 실패 기록] paymentId={}, meetingId={}, userId={}, error={}",
 			payment.getId(), meetingId, payment.getUserId(), errorMessage);
+	}
+
+	private void safeAck(Channel ch, long tag) {
+		try {
+			ch.basicAck(tag, false);
+		} catch (Exception e) {
+			log.error("ACK 실패", e);
+		}
 	}
 }

--- a/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
+++ b/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
@@ -58,11 +58,13 @@ public class PaymentEventConsumer {
 		long tag = msg.getMessageProperties().getDeliveryTag();
 		Long meetingId = null, userId = null;
 
+		// NULL payload: ack 후 드랍
+		if (wrapper == null || wrapper.data() == null) {
+			log.warn("[register] null payload - ack & drop (no dlq) ");
+			safeAck(ch, tag);
+			return;
+		}
 		try {
-			// 즉시 DLQ: NULL
-			if (wrapper == null || wrapper.data() == null) {
-				throw new AmqpRejectAndDontRequeueException("[register] null payload");
-			}
 
 			// 즉시 DLQ: 타입 불일치
 			if (!MEETING_PARTICIPANT_REGISTER.equals(wrapper.type())) {
@@ -121,11 +123,14 @@ public class PaymentEventConsumer {
 	public void handleParticipantCancel(EventWrapper<?> wrapper, Channel ch, Message msg) {
 		long tag = msg.getMessageProperties().getDeliveryTag();
 
+		// NULL payload: ack 후 드랍
+		if (wrapper == null || wrapper.data() == null) {
+			log.warn("[cancel] null payload - ack & drop (no dlq)");
+			safeAck(ch, tag);
+			return;
+		}
+
 		try {
-			// 즉시 DLQ: NULL
-			if (wrapper == null || wrapper.data() == null) {
-				throw new AmqpRejectAndDontRequeueException("[cancel] null payload");
-			}
 
 			// 즉시 DLQ: 타입 불일치
 			if (!MEETING_PARTICIPANT_CANCEL.equals(wrapper.type())) {

--- a/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
+++ b/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
@@ -15,8 +15,10 @@ import com.example.momo.domain.payment.application.dto.RefundRequestDto;
 import com.example.momo.domain.payment.domain.Payment;
 import com.example.momo.domain.payment.domain.PaymentRepository;
 import com.example.momo.domain.payment.enums.PaymentStatus;
+import com.example.momo.global.rabbitmq.dto.common.EventWrapper;
 import com.example.momo.global.rabbitmq.dto.meeting.ParticipantEvents;
 import com.example.momo.global.springEvent.meeting.MeetingMessageEvents;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.Channel;
 
 import lombok.RequiredArgsConstructor;
@@ -34,11 +36,12 @@ public class PaymentEventConsumer {
 
 	private final PaymentRepository paymentRepository;
 	private final PaymentService paymentService;
+	private final ObjectMapper objectMapper;
 
 	/**
 	 * 1. 참가자 등록 이벤트 처리 - 결제 생성
 	 * Queue: payment.participant.registered.queue
-	 * Event: ParticipantEvents.Register (meetingId, userId)
+	 * EventWrapper<ParticipantEvents.Register>를 수신
 	 *
 	 * Meeting에서 참가 신청 시 발행하는 이벤트
 	 * 결제 처리 후 payment.completed 또는 payment.failed 이벤트 발행
@@ -47,16 +50,22 @@ public class PaymentEventConsumer {
 		queues = PAYMENT_PARTICIPANT_REGISTER,
 		containerFactory = "paymentListenerContainerFactory"
 	)
-	public void handleParticipantRegister(ParticipantEvents.Register event,
+	public void handleParticipantRegister(EventWrapper<?> eventWrapper,
 		Channel channel,
 		Message message) {
 		long deliveryTag = message.getMessageProperties().getDeliveryTag();
 
-		log.info("[결제 시작] 참가자 등록 이벤트 수신 - meetingId: {}, userId: {}",
-			event.meetingId(), event.userId());
-
 		try {
-			// 이미 결제 완료된 경우 체크 (중복 방지)
+			// EventWrapper의 data를 ParticipantEvents.Register로 변환
+			ParticipantEvents.Register event = objectMapper.convertValue(
+				eventWrapper.data(),
+				ParticipantEvents.Register.class
+			);
+
+			log.info("[결제 시작] 참가자 등록 이벤트 수신 - meetingId: {}, userId: {}",
+				event.meetingId(), event.userId());
+
+			// 이미 결제 완료된 경우 체크 (멱등성)
 			if (paymentRepository.existsByMeetingIdAndUserIdAndStatus(
 				event.meetingId(), event.userId(), PaymentStatus.COMPLETED)) {
 				log.warn("이미 결제 완료됨 – meetingId={}, userId={}",
@@ -65,10 +74,7 @@ public class PaymentEventConsumer {
 				return;
 			}
 
-			// 결제 실행 (Service에서 결제 생성 및 처리)
-			// createTestKeyInPayment 내부에서:
-			// - 성공 시: payment.completed 이벤트 발행
-			// - 실패 시: payment.failed 이벤트 발행
+			// 결제 실행
 			CardPaymentTestRequestDto request = CardPaymentTestRequestDto.builder()
 				.meetingId(event.meetingId())
 				.build();
@@ -80,16 +86,15 @@ public class PaymentEventConsumer {
 				event.meetingId(), event.userId());
 
 		} catch (Exception ex) {
-			log.error("[결제 처리 실패] meetingId={}, userId={}, error={}",
-				event.meetingId(), event.userId(), ex.getMessage());
-			handleMessageFailure(channel, deliveryTag, event.meetingId(), event.userId());
+			log.error("[결제 처리 실패] wrapper={}, error={}", eventWrapper, ex.getMessage(), ex);
+			handleMessageFailure(channel, deliveryTag, null, null);
 		}
 	}
 
 	/**
 	 * 2. 참가자 취소 이벤트 처리 - 개별 환불
 	 * Queue: payment.participant.canceled.queue
-	 * Event: ParticipantEvents.Cancel
+	 * EventWrapper<ParticipantEvents.Cancel>을 수신
 	 * (meetingId, userId, hostUserId, participantNickname, refundRequired, amount)
 	 *
 	 * Meeting에서 참가 취소 시 발행하는 이벤트
@@ -99,17 +104,23 @@ public class PaymentEventConsumer {
 		queues = PAYMENT_PARTICIPANT_CANCEL,
 		containerFactory = "paymentListenerContainerFactory"
 	)
-	public void handleParticipantCancel(ParticipantEvents.Cancel event,
+	public void handleParticipantCancel(EventWrapper<?> eventWrapper,
 		Channel channel,
 		Message message) {
 		long deliveryTag = message.getMessageProperties().getDeliveryTag();
 
-		log.info("[환불 시작] 참가자 취소 이벤트 수신 - meetingId: {}, userId: {}, nickname: {}",
-			event.meetingId(), event.userId(), event.participantNickname());
-
 		try {
+			// EventWrapper의 data를 ParticipantEvents.Cancel로 변환
+			ParticipantEvents.Cancel event = objectMapper.convertValue(
+				eventWrapper.data(),
+				ParticipantEvents.Cancel.class
+			);
+
+			log.info("[환불 시작] 참가자 취소 이벤트 수신 - meetingId: {}, userId: {}, nickname: {}",
+				event.meetingId(), event.userId(), event.participantNickname());
+
 			if (!event.refundRequired()) {
-				log.warn("환불 필요 없음 - meetingId: {}, userId: {}",
+				log.info("환불 불필요 (무료 모임) - meetingId: {}, userId: {}",
 					event.meetingId(), event.userId());
 				channel.basicAck(deliveryTag, false);
 				return;
@@ -128,10 +139,6 @@ public class PaymentEventConsumer {
 			}
 
 			// 환불 처리
-			// refundPayment 내부에서:
-			// 1. 토스 API 호출하여 환불
-			// 2. payment.refunded 이벤트 발행
-			// 3. 결제 레코드 삭제 (재결제 가능하도록)
 			RefundRequestDto refundRequest = new RefundRequestDto(
 				String.format("사용자 %s님의 참가 취소", event.participantNickname())
 			);
@@ -143,16 +150,15 @@ public class PaymentEventConsumer {
 				payment.getId(), event.meetingId(), event.userId(), payment.getAmount());
 
 		} catch (Exception ex) {
-			log.error("[환불 실패] meetingId={}, userId={}, error={}",
-				event.meetingId(), event.userId(), ex.getMessage());
-			handleMessageFailure(channel, deliveryTag, event.meetingId(), event.userId());
+			log.error("[환불 실패] wrapper={}, error={}", eventWrapper, ex.getMessage(), ex);
+			handleMessageFailure(channel, deliveryTag, null, null);
 		}
 	}
 
 	/**
 	 * 3. 모임 삭제 이벤트 처리 - 전체 참가자 환불
 	 * Queue: payment.meeting.deleted.queue
-	 * Event: MeetingMessageEvents.Delete (meetingId, meetingName, userIdList)
+	 * EventWrapper로 수신예정 (아직 모임삭제 쪽에서 반영이 안되어있어서 springevent로 발행되고 있는 상황)
 	 *
 	 * Meeting 삭제 시 발행하는 이벤트
 	 * 모든 참가자의 결제를 환불 처리

--- a/src/main/java/com/example/momo/domain/payment/event/rabbitmq/producer/PaymentEventProducer.java
+++ b/src/main/java/com/example/momo/domain/payment/event/rabbitmq/producer/PaymentEventProducer.java
@@ -82,7 +82,7 @@ public class PaymentEventProducer {
 			// Publisher Confirm 대기
 			try {
 				CorrelationData.Confirm confirm = correlationData.getFuture()
-					.get(10, TimeUnit.SECONDS);
+					.get(5, TimeUnit.SECONDS);
 
 				if (confirm != null && confirm.isAck()) {
 					log.info("[Payment] Publisher Confirm ACK - outboxId={}", outboxId);

--- a/src/main/java/com/example/momo/global/rabbitmq/constant/RoutingKeys.java
+++ b/src/main/java/com/example/momo/global/rabbitmq/constant/RoutingKeys.java
@@ -26,9 +26,9 @@ public class RoutingKeys {
 	public static final String MEETING_DELETE = "meeting.deleted";
 
 	// Payment 관련 key
-	public static final String PAYMENT_COMPLETED_KEY = "payment.completed";
-	public static final String PAYMENT_FAILED_KEY = "payment.failed";
-	public static final String PAYMENT_REFUNDED_KEY = "payment.refunded";
+	public static final String PAYMENT_COMPLETED_KEY = "payment.completed.key";
+	public static final String PAYMENT_FAILED_KEY = "payment.failed.key";
+	public static final String PAYMENT_REFUNDED_KEY = "payment.refunded.key";
 	public static final String PAYMENT_DLQ = "payment.dlq";
 
 }


### PR DESCRIPTION
### PR Title

`feat(payment): participant 이벤트를 EventWrapper로 수신, DLQ 정책 정비`

### PR Description

* **Consumer**

  * `EventWrapper` 기반으로 `participant.registered`/`participant.canceled` 수신
  * 타입불일치/역직렬화 실패/필수필드 누락 → `AmqpRejectAndDontRequeueException`(즉시 DLQ)
  * NULL은 ACK 후 return (예외처리만 하면 브로커에 prefetch가 꽉 차게 됩니다)
  * 비즈니스 예외(`PaymentException`)는 ACK 
     * 결제(Create) 중 실패: 서비스에서 outbox 실패 이벤트 저장 + PaymentEvents.Failed 발행.
    * 환불(Refund) 중 실패: 이벤트 발행 없음, 로그/기록만 남김.
* **컨슈머 레벨** 시스템/일시적 예외: `RuntimeException` 재던짐 → 컨테이너 재시도 후 DLQ.
  *(서비스 내부 시스템 예외는 `PaymentException`으로 변환되어 올라오므로 컨슈머에서는 ACK)*

* **Service**
  * createTestKeyInPayment 실패 시 payment.fail() 기록 후 saveFailedOutboxEvent + PaymentEvents.Failed 발행
  * `@Transactional(noRollbackFor = PaymentException.class)`로 실패 이벤트(outbox) 커밋 보장

* **Routing**
routing key 뒤쪽에 .key 추가해줬습니다


-----


현재 테스트에서 해당 로직들 잘 되는 것으로 확인했습니다.

