### PR TITLE
feat(payment): 모임 이벤트에서 온 uuid를 결제 도메인 이벤트에 전파

### DIFF
--- a/src/main/java/com/example/momo/domain/payment/application/PaymentService.java
+++ b/src/main/java/com/example/momo/domain/payment/application/PaymentService.java
@@ -12,10 +12,14 @@ import com.example.momo.domain.payment.enums.PaymentStatus;
 
 public interface PaymentService {
 
+	PaymentResponseDto createTestKeyInPayment(CardPaymentTestRequestDto request, Long userId);
+
 	//테스트 key-in 결제
-	PaymentResponseDto createTestKeyInPayment(CardPaymentTestRequestDto dto, Long userId);
+	PaymentResponseDto createTestKeyInPayment(CardPaymentTestRequestDto dto, Long userId, String correlationUuid);
 
 	//환불 처리
+	PaymentResponseDto refundPayment(Long paymentId, Long userId, RefundRequestDto request, String correlationUuid);
+
 	PaymentResponseDto refundPayment(Long paymentId, Long userId, RefundRequestDto request);
 
 	//조회 메서드들

--- a/src/main/java/com/example/momo/domain/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/payment/application/PaymentServiceImpl.java
@@ -58,13 +58,20 @@ public class PaymentServiceImpl implements PaymentService {
 
 	// ==================== 결제 생성 ====================
 
+	@Override
+	public PaymentResponseDto createTestKeyInPayment(CardPaymentTestRequestDto request, Long userId) {
+		// 컨트롤러에서 호출 시 correlation 없이 진행 (내부에서 새 UUID 생성됨)
+		return createTestKeyInPayment(request, userId, null);
+	}
+
 	/**
 	 * 테스트 Key-in 결제 처리 - 카드번호를 직접 입력하여 결제를 진행하는 테스트 전용 메서드
 	 * PENDING 결제가 있으면 재사용, 없으면 새로 생성
 	 */
 	@Override
 	@Transactional(noRollbackFor = PaymentException.class)
-	public PaymentResponseDto createTestKeyInPayment(CardPaymentTestRequestDto request, Long userId) {
+	public PaymentResponseDto createTestKeyInPayment(CardPaymentTestRequestDto request, Long userId,
+		String correlationUuid) {
 		Long meetingId = request.getMeetingId();
 		Payment payment = null;
 
@@ -111,7 +118,8 @@ public class PaymentServiceImpl implements PaymentService {
 			LocalDateTime approvedAt = OffsetDateTime.parse(result.getApprovedAt()).toLocalDateTime();
 			payment.complete(result.getPaymentKey(), orderId, approvedAt);
 
-			Long outboxId = saveOutboxEvent(payment, "PAYMENT_COMPLETED", RoutingKeys.PAYMENT_COMPLETED_KEY);
+			Long outboxId = saveOutboxEvent(payment, "PAYMENT_COMPLETED", RoutingKeys.PAYMENT_COMPLETED_KEY,
+				correlationUuid);
 			eventPublisher.publishEvent(new PaymentEvents.Completed(
 				payment.getId(), payment.getUserId(), payment.getMeetingId(), payment.getAmount(), orderId, outboxId));
 
@@ -124,10 +132,10 @@ public class PaymentServiceImpl implements PaymentService {
 				payment.fail(pe.getMessage());
 			}
 			Long outboxId = saveFailedOutboxEvent(
-				payment != null ? payment.getId() : null, meetingId, userId, pe.getMessage());
+				payment != null ? payment.getId() : null, meetingId, userId, pe.getMessage(), correlationUuid);
 			eventPublisher.publishEvent(new PaymentEvents.Failed(
 				payment != null ? payment.getId() : null, userId, meetingId, pe.getMessage(), outboxId));
-			throw pe; // 그대로 전파ㅂㅂ
+			throw pe; // 그대로 전파
 
 		} catch (Exception e) {
 			// 시스템/외부 예외도 '실패 이벤트' 발행
@@ -135,7 +143,7 @@ public class PaymentServiceImpl implements PaymentService {
 				payment.fail(e.getMessage());
 			}
 			Long outboxId = saveFailedOutboxEvent(
-				payment != null ? payment.getId() : null, meetingId, userId, e.getMessage());
+				payment != null ? payment.getId() : null, meetingId, userId, e.getMessage(), correlationUuid);
 			eventPublisher.publishEvent(new PaymentEvents.Failed(
 				payment != null ? payment.getId() : null, userId, meetingId, e.getMessage(), outboxId));
 			throw new PaymentException(PaymentErrorCode.TOSS_CONFIRM_FAILED);
@@ -144,12 +152,19 @@ public class PaymentServiceImpl implements PaymentService {
 
 	// ==================== 환불 처리 ====================
 
+	@Override
+	public PaymentResponseDto refundPayment(Long paymentId, Long userId, RefundRequestDto request) {
+		// 컨트롤러에서 호출 시 correlation 없이 진행 (내부에서 새 UUID 생성됨)
+		return refundPayment(paymentId, userId, request, null);
+	}
+
 	/**
 	 * 결제 환불 처리 - 환불 후 재결제가 가능하도록 레코드 삭제
 	 */
 	@Override
 	@Transactional(noRollbackFor = PaymentException.class)
-	public PaymentResponseDto refundPayment(Long paymentId, Long userId, RefundRequestDto request) {
+	public PaymentResponseDto refundPayment(Long paymentId, Long userId, RefundRequestDto request,
+		String correlationUuid) {
 		Payment payment = null;
 
 		try {
@@ -184,7 +199,7 @@ public class PaymentServiceImpl implements PaymentService {
 
 			// Outbox 저장 및 도메인 이벤트 발행
 			Long outboxId = saveOutboxEvent(payment, "PAYMENT_REFUNDED", RoutingKeys.PAYMENT_REFUNDED_KEY,
-				request.getReason());
+				request.getReason(), null);
 			eventPublisher.publishEvent(new PaymentEvents.Refunded(
 				payment.getId(),
 				payment.getUserId(),
@@ -203,7 +218,7 @@ public class PaymentServiceImpl implements PaymentService {
 				payment != null ? payment.getId() : null, userId, pe.getMessage());
 			recordRefundFailure(payment, payment != null ? payment.getMeetingId() : null, pe.getMessage());
 			throw pe;
-			
+
 		} catch (Exception e) {
 			log.error("[환불 실패-시스템] paymentId={}, userId={}, err={}",
 				payment != null ? payment.getId() : null, userId, e.getMessage(), e);
@@ -213,11 +228,12 @@ public class PaymentServiceImpl implements PaymentService {
 		}
 	}
 
-	private Long saveOutboxEvent(Payment payment, String eventType, String routingKey) {
-		return saveOutboxEvent(payment, eventType, routingKey, null);
+	private Long saveOutboxEvent(Payment payment, String eventType, String routingKey, String correlationUuid) {
+		return saveOutboxEvent(payment, eventType, routingKey, null, correlationUuid);
 	}
 
-	private Long saveOutboxEvent(Payment payment, String eventType, String routingKey, String refundReason) {
+	private Long saveOutboxEvent(Payment payment, String eventType, String routingKey, String refundReason,
+		String correlationUuid) {
 		try {
 			Object eventMessage;
 			// 1) 이벤트 DTO 구성 (outboxId는 헤더로 보내므로 DTO 필드는 null로 둬도 됨)
@@ -225,7 +241,7 @@ public class PaymentServiceImpl implements PaymentService {
 				case "PAYMENT_COMPLETED" -> eventMessage = new PaymentEventMessages.Completed(
 					payment.getId(), payment.getUserId(), payment.getMeetingId(),
 					payment.getAmount(),
-					payment.getOrderId() != null ? payment.getOrderId() : "", // orderId가 필요하면 저장
+					payment.getOrderId() != null ? payment.getOrderId() : "",
 					null
 				);
 				case "PAYMENT_FAILED" -> eventMessage = new PaymentEventMessages.Failed(
@@ -250,8 +266,10 @@ public class PaymentServiceImpl implements PaymentService {
 				default -> throw new IllegalArgumentException("Unknown event type: " + eventType);
 			};
 
-			// 3) Wrapper로 감싸기
-			EventWrapper<Object> wrapper = EventWrapper.of(wrapperType, eventMessage);
+			// 3) Wrapper로 감싸기(register uuid 재사용)
+			EventWrapper<Object> wrapper = (correlationUuid != null && !correlationUuid.isBlank())
+				? EventWrapper.of(correlationUuid, wrapperType, eventMessage)
+				: EventWrapper.of(wrapperType, eventMessage); // 방어적 fallback
 
 			// 4) Outbox payload에 Wrapper JSON 저장
 			String payload = objectMapper.writeValueAsString(wrapper);
@@ -272,13 +290,17 @@ public class PaymentServiceImpl implements PaymentService {
 		}
 	}
 
-	private Long saveFailedOutboxEvent(Long paymentId, Long meetingId, Long userId, String reason) {
+	private Long saveFailedOutboxEvent(Long paymentId, Long meetingId, Long userId, String reason,
+		String correlationUuid) {
 		try {
 			PaymentEventMessages.Failed msg = new PaymentEventMessages.Failed(
 				paymentId, userId, meetingId, (reason != null ? reason : "결제 실패"), null
 			);
 
-			EventWrapper<Object> wrapper = EventWrapper.of(EventTypeNames.PAYMENT_FAILED, msg);
+			// ★ 실패도 같은 uuid 유지
+			EventWrapper<Object> wrapper = (correlationUuid != null && !correlationUuid.isBlank())
+				? EventWrapper.of(correlationUuid, EventTypeNames.PAYMENT_FAILED, msg)
+				: EventWrapper.of(EventTypeNames.PAYMENT_FAILED, msg);
 			String payload = objectMapper.writeValueAsString(wrapper);
 
 			// Payment 엔티티가 없을 수 있으니, aggregateId를 안전하게 구성

--- a/src/main/java/com/example/momo/domain/payment/event/rabbitmq/config/PaymentRabbitConfig.java
+++ b/src/main/java/com/example/momo/domain/payment/event/rabbitmq/config/PaymentRabbitConfig.java
@@ -15,6 +15,8 @@ import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.interceptor.RetryOperationsInterceptor;
 import org.springframework.retry.support.RetryTemplate;
 
+import com.example.momo.global.rabbitmq.constant.RoutingKeys;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -63,9 +65,30 @@ public class PaymentRabbitConfig {
 		RabbitTemplate template = new RabbitTemplate(connectionFactory);
 		template.setMessageConverter(messageConverter);
 
-		// 라우팅 실패 시 ReturnCallback이 동작하도록 설정
+		// 관측은 하되, 성공/실패 판단은 Confirm으로만
 		template.setMandatory(true);
 
+		// 라우팅 실패: 로그만 남기고 비즈니스 실패로 보지 않음
+		template.setReturnsCallback(ret -> {
+			String rk = ret.getRoutingKey();
+			// 환불 이벤트만: 소비자 없음 -> 정상 케이스로 간주 (로그만)
+			if (!RoutingKeys.PAYMENT_REFUNDED_KEY.equals(rk)) {
+				log.error("[Payment] UNROUTABLE message. ex={}, key={}, code={}, text={}",
+					ret.getExchange(), rk, ret.getReplyCode(), ret.getReplyText());
+			}
+		});
+		// 발행 성공/실패는 오직 Confirm으로 판단
+		template.setConfirmCallback((corr, ack, cause) -> {
+			String cid = corr != null ? corr.getId() : null;
+			if (ack) {
+				log.info("[Payment] Publish CONFIRMED cid={}", cid);
+			} else {
+				log.error("[Payment] Publish NACK cid={}, cause={}", cid, cause);
+
+			}
+		});
+
+		// 채널/네트워크 오류 재시도
 		// --- Retry 설정 (지수 백오프) ---
 		RetryTemplate retry = new RetryTemplate();
 		ExponentialBackOffPolicy backOff = new ExponentialBackOffPolicy();
@@ -74,19 +97,6 @@ public class PaymentRabbitConfig {
 		backOff.setMaxInterval(10_000);    // 최대 대기 시간: 10초
 		retry.setBackOffPolicy(backOff);
 		template.setRetryTemplate(retry);
-		// Confirm/Return Callback (로깅용)
-		template.setConfirmCallback((correlationData, ack, cause) -> {
-			if (ack) {
-				log.info("Confirm 성공 - correlationId={}", correlationData.getId());
-			} else {
-				log.error("Confirm 실패 - correlationId={}, cause={}", correlationData.getId(), cause);
-			}
-		});
-
-		// --- 라우팅 실패 시 로그 출력 ---
-		template.setReturnsCallback(ret -> log.error(
-			"[Payment] 라우팅 실패 - exchange: {}, routingKey: {}, message: {}",
-			ret.getExchange(), ret.getRoutingKey(), ret.getMessage()));
 
 		return template;
 	}

--- a/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
+++ b/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
@@ -203,21 +203,41 @@ public class PaymentEventConsumer {
 		queues = PAYMENT_MEETING_DELETED,
 		containerFactory = "paymentListenerContainerFactory"
 	)
-	public void handleMeetingDeleted(MeetingMessageEvents.Delete event, Channel ch, Message msg) {
+	public void handleMeetingDeleted(EventWrapper<?> wrapper, Channel ch, Message msg) {
 		long tag = msg.getMessageProperties().getDeliveryTag();
 
+		// NULL payload: ack 후 드랍
+		if (wrapper == null || wrapper.data() == null) {
+			log.warn("[meeting.deleted] null payload - ack & drop (no dlq)");
+			safeAck(ch, tag);
+			return;
+		}
+
 		try {
-			// 즉시 DLQ: NULL/필수 누락
-			if (event == null || event.meetingId() == null) {
-				throw new AmqpRejectAndDontRequeueException("[meeting.deleted] null event or missing meetingId");
+			// 즉시 DLQ: 타입 불일치
+			if (!MEETING_DELETE.equals(wrapper.type())) {
+				throw new AmqpRejectAndDontRequeueException("[meeting.deleted] wrong type: " + wrapper.type());
+			}
+
+			// 즉시 DLQ: 역직렬화 실패
+			final MeetingMessageEvents.Delete ev;
+			try {
+				ev = objectMapper.convertValue(wrapper.data(), MeetingMessageEvents.Delete.class);
+			} catch (Exception cvt) {
+				throw new AmqpRejectAndDontRequeueException("[meeting.deleted] deserialize fail", cvt);
+			}
+
+			// 즉시 DLQ: 필수 필드 누락
+			if (ev.meetingId() == null) {
+				throw new AmqpRejectAndDontRequeueException("[meeting.deleted] missing meetingId");
 			}
 
 			log.info("[모임 삭제 환불] meetingId={}, meetingName={}, 참가자={}명",
-				event.meetingId(), event.meetingName(),
-				event.userIdList() != null ? event.userIdList().size() : 0);
+				ev.meetingId(), ev.meetingName(),
+				ev.userIdList() != null ? ev.userIdList().size() : 0);
 
 			List<Payment> completed = paymentRepository.findByMeetingIdAndStatus(
-				event.meetingId(), PaymentStatus.COMPLETED);
+				ev.meetingId(), PaymentStatus.COMPLETED);
 
 			if (completed.isEmpty()) {
 				ch.basicAck(tag, false);
@@ -225,21 +245,25 @@ public class PaymentEventConsumer {
 			}
 
 			int ok = 0, fail = 0;
+			String corr = wrapper.uuId();
+
 			for (Payment payment : completed) {
 				try {
 					RefundRequestDto refundRequest = new RefundRequestDto(
-						String.format("모임 '%s' 삭제로 인한 자동 환불", event.meetingName()));
-					paymentService.refundPayment(payment.getId(), payment.getUserId(), refundRequest);
+						String.format("모임 '%s' 삭제로 인한 자동 환불", ev.meetingName()));
+
+					paymentService.refundPayment(payment.getId(), payment.getUserId(), refundRequest, corr);
+
 					ok++;
 				} catch (Exception refundEx) {
 					fail++;
 					log.error("[환불 실패] paymentId={}, err={}", payment.getId(), refundEx.getMessage(), refundEx);
-					recordRefundFailure(payment, event.meetingId(), refundEx.getMessage());
+					recordRefundFailure(payment, ev.meetingId(), refundEx.getMessage());
 				}
 			}
 
 			log.info("[모임 삭제 환불 완료] 성공:{}건, 실패:{}건", ok, fail);
-			// 부분 실패여도 ACK (환불 실패건은 별도 관리)
+			// 부분 실패여도 ACK (실패건은 별도 기록/후처리)
 			ch.basicAck(tag, false);
 
 		} catch (AmqpRejectAndDontRequeueException reject) {

--- a/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
+++ b/src/main/java/com/example/momo/domain/payment/event/rabbitmq/consumer/PaymentEventConsumer.java
@@ -90,9 +90,10 @@ public class PaymentEventConsumer {
 
 			// 결제 비즈니스
 			log.info("[결제 시작] meetingId={}, userId={}", meetingId, userId);
-			CardPaymentTestRequestDto req = CardPaymentTestRequestDto.builder()
+			CardPaymentTestRequestDto request = CardPaymentTestRequestDto.builder()
 				.meetingId(meetingId).build();
-			paymentService.createTestKeyInPayment(req, userId);
+			String corr = wrapper.uuId(); //Register의 uuid
+			paymentService.createTestKeyInPayment(request, userId, corr);
 
 			// 성공 -> ACK
 			ch.basicAck(tag, false);
@@ -173,7 +174,8 @@ public class PaymentEventConsumer {
 			// 환불 처리
 			RefundRequestDto refundRequest = new RefundRequestDto(
 				String.format("사용자 %s님의 참가 취소", ev.participantNickname()));
-			paymentService.refundPayment(payment.getId(), ev.userId(), refundRequest);
+			String corr = wrapper.uuId();
+			paymentService.refundPayment(payment.getId(), ev.userId(), refundRequest, corr);
 
 			// 성공 -> ACK
 			ch.basicAck(tag, false);

--- a/src/main/java/com/example/momo/domain/payment/event/rabbitmq/producer/PaymentEventProducer.java
+++ b/src/main/java/com/example/momo/domain/payment/event/rabbitmq/producer/PaymentEventProducer.java
@@ -74,6 +74,8 @@ public class PaymentEventProducer {
 				message -> {
 					message.getMessageProperties()
 						.setHeader("x-outbox-id", outbox.getId());
+					message.getMessageProperties().
+						setHeader("x-correlation-id", wrapper.uuId());
 					return message;
 				},
 				correlationData

--- a/src/main/java/com/example/momo/domain/payment/event/rabbitmq/producer/PaymentEventProducer.java
+++ b/src/main/java/com/example/momo/domain/payment/event/rabbitmq/producer/PaymentEventProducer.java
@@ -12,6 +12,7 @@ import com.example.momo.domain.payment.domain.PaymentOutbox;
 import com.example.momo.domain.payment.domain.PaymentOutboxRepository;
 import com.example.momo.domain.payment.enums.OutboxStatus;
 import com.example.momo.global.rabbitmq.constant.RabbitExchangeNames;
+import com.example.momo.global.rabbitmq.constant.RoutingKeys;
 import com.example.momo.global.rabbitmq.dto.common.EventWrapper;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -86,12 +87,21 @@ public class PaymentEventProducer {
 				CorrelationData.Confirm confirm = correlationData.getFuture()
 					.get(5, TimeUnit.SECONDS);
 
-				if (confirm != null && confirm.isAck()) {
-					log.info("[Payment] Publisher Confirm ACK - outboxId={}", outboxId);
+				boolean isRefund = RoutingKeys.PAYMENT_REFUNDED_KEY.equals(outbox.getRoutingKey());
 
+				if (confirm != null && confirm.isAck()) {
+					// 브로커까지는 도착
 					if (correlationData.getReturned() != null) {
-						log.warn("[Payment] 라우팅 실패 - outboxId={}", outboxId);
-						outboxService.markEventAsFailed(outboxId, "라우팅 실패");
+						// 교환기 -> 큐 라우팅 실패
+						if (isRefund) {
+							//  환불은 소비자 없음이 정상 -> 성공 처리
+							log.info("[Payment] Refund unroutable 정상 outboxId={}", outboxId);
+							outboxService.markEventAsPublished(outboxId);
+						} else {
+							// 그 외 이벤트는 실패 처리
+							log.warn("[Payment] Unroutable 실패 outboxId={}", outboxId);
+							outboxService.markEventAsFailed(outboxId, "라우팅 실패");
+						}
 					} else {
 						outboxService.markEventAsPublished(outboxId);
 						log.info("[Payment] 이벤트 발행 성공 - outboxId={}", outboxId);


### PR DESCRIPTION
## 제목

feat(payment): 모임 이벤트의 uuId를 결제 도메인 이벤트에 전파

## 변경사항

- MEETING_PARTICIPANT_REGISTER의 uuId를 PAYMENT_COMPLETED/FAILED/REFUNDED에 재사용
- EventWrapper.of(correlationUuid, ...)로 Wrapper 생성
- Producer가 'x-correlation-id' 헤더에 wrapper uuId 설정

-환불 이벤트 발행시 수신하는 곳이 없어 unroutable 시 로그만 처리했습니다
(성공/실패 판정은 confirm ack로만 수행합니다)


---
## 상황 설명

오류 해결을 위해 register와 모임 취소 시 받은 uuid를 결제 도메인 이벤트에서 발행하도록 고쳤습니다.


모임 삭제 로직에서 meetingProducer에 레빗템플릿에 라우팅 키 이름을 MEETING_DELETE_KEY 이걸로 고치셔야 삭제 로직이 작동합니다. 삭제 후에 payments 레코드가 삭제되는 건 확인되는데  MeetingPaymentListener에서 Exception에 걸려 log.error가 뜨긴 합니다.


