### PR TITLE
Feat/caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ gradle.properties
 src/main/resources/firebase/*
 src/main/resources/static/firebase/*
 
+### MAC 자동 생성 파일 ###
+.DS_Store

--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
@@ -8,6 +8,8 @@ import com.example.momo.global.rabbitmq.dto.common.EventWrapper;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -152,6 +154,7 @@ public class MeetingServiceImpl implements MeetingService {
 
 	@Override
 	@Transactional(readOnly = true)
+	@Cacheable(value = "meeting", key = "#meetingId",cacheManager = "cacheManager")
 	public MeetingResponseDto getMeeting(Long meetingId) {
 
 		Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
@@ -303,6 +306,7 @@ public class MeetingServiceImpl implements MeetingService {
 
 	@Override
 	@Transactional
+	@CacheEvict(value = "meeting", key = "#meetingId")
 	public ParticipantCreateResponseDto createParticipant(Long userId, Long meetingId) {
 
 		RLock lock = redissonClient.getLock("lock:meeting:" + meetingId);

--- a/src/main/java/com/example/momo/domain/meeting/application/dto/response/MeetingResponseDto.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/dto/response/MeetingResponseDto.java
@@ -5,28 +5,31 @@ import java.time.LocalDateTime;
 import com.example.momo.domain.meeting.domain.Meeting;
 import com.example.momo.domain.meeting.enums.MeetingStatus;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-public class MeetingResponseDto {
+@NoArgsConstructor
+public class MeetingResponseDto{
 
-	private final Long id;
-	private final Long hostUserId;
-	private final String title;
-	private final String description;
-	private final Integer categoryId;
-	private final int currentParticipantsCount;
-	private final int maxParticipantsCount;
-	private final LocalDateTime meetingDate;
-	private final LocalDateTime meetingEndDate;
-	private final String locationName;
-	private final Double latitude;
-	private final Double longitude;
-	private final Double minEnterScore;
-	private final int participationFee;
-	private final MeetingStatus status;
-	private final LocalDateTime createdAt;
-	private final LocalDateTime updatedAt;
+	private Long id;
+	private Long hostUserId;
+	private String title;
+	private String description;
+	private Integer categoryId;
+	private int currentParticipantsCount;
+	private int maxParticipantsCount;
+	private LocalDateTime meetingDate;
+	private LocalDateTime meetingEndDate;
+	private String locationName;
+	private Double latitude;
+	private Double longitude;
+	private Double minEnterScore;
+	private int participationFee;
+	private MeetingStatus status;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
 
 	public MeetingResponseDto(Meeting meeting) {
 		this.id = meeting.getId();

--- a/src/main/java/com/example/momo/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/momo/global/config/RedisCacheConfig.java
@@ -1,0 +1,60 @@
+package com.example.momo.global.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.example.momo.domain.meeting.application.dto.response.MeetingResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+	@Bean
+	public CacheManager cacheManager(RedisConnectionFactory cf, ObjectMapper objectMapper) {
+		new Jackson2JsonRedisSerializer<>(MeetingResponseDto.class);
+
+		// 공통 기본 설정 (키=String, 값=JSON, 기본 TTL=5분)
+		RedisCacheConfiguration defaultCfg = RedisCacheConfiguration.defaultCacheConfig()
+		// 키는 항상 String
+		.serializeKeysWith(
+			RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+		// value는 JSON (타입 정보도 포함됨)
+		.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper)))
+		// "cacheName::key" 형태(prefix 추가)
+		.computePrefixWith(CacheKeyPrefix.simple())
+		// null 결과는 캐시하지 않음
+		.disableCachingNullValues()
+		// 기본 TTL
+		.entryTtl(Duration.ofMinutes(3));
+
+		// meeting 전용 직렬화기
+		Jackson2JsonRedisSerializer<MeetingResponseDto> meetingSerializer = new Jackson2JsonRedisSerializer<>(objectMapper,MeetingResponseDto.class);
+
+
+		// 캐시별 오버라이드
+		RedisCacheConfiguration meetingCfg = defaultCfg
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(meetingSerializer))
+			.entryTtl(Duration.ofMinutes(5));
+
+		RedisCacheConfiguration userCfg    = defaultCfg.entryTtl(Duration.ofMinutes(10));
+
+		return RedisCacheManager.builder(cf)
+			.cacheDefaults(defaultCfg)                  // 기본: 5분
+			.withCacheConfiguration("meeting", meetingCfg) // meeting 전용
+			// .withCacheConfiguration("user", userCfg)
+			.build();
+	}
+}


### PR DESCRIPTION
1. 캐시 설정
2. MeetingServiceImpl 에 캐시관련 애노테이션 추가
3. MeetingResponseDto가 Redis에서 역직렬화가 불가능하여 final 을 지우고 기본 생성자를 추가했습니다.

+ 대용량 트래픽에서 캐시를 사용할 때 발생하는 문제점 중에 "캐시 쇄도(Cache Stampede)", "캐시 관통(Cache Penetration)", "핫키 (Hotkey) 만료" 를 해결하던 중에 어려움을 겪어서 일단 기본 캐싱만 PR 올립니다 :(  

캐싱 관련한 설명은 5분 기록보드에 올려놓겠습니다.