### PR TITLE
refactor: 엔티티와 ddl 데이터 일치 시켜줌

### DIFF
--- a/src/main/java/com/example/momo/domain/payment/domain/PaymentOutbox.java
+++ b/src/main/java/com/example/momo/domain/payment/domain/PaymentOutbox.java
@@ -42,8 +42,10 @@ public class PaymentOutbox {
 	@Column(nullable = false)
 	private LocalDateTime createdAt;
 
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 
+	@Column(name = "published_at")
 	private LocalDateTime publishedAt;
 
 	@Column(nullable = false)

--- a/src/main/resources/db/migration/V13__Create_payment_outbox_table.sql
+++ b/src/main/resources/db/migration/V13__Create_payment_outbox_table.sql
@@ -11,7 +11,8 @@ CREATE TABLE payment_outbox
     published      BOOLEAN      NOT NULL DEFAULT FALSE,
     retry_count    INT          DEFAULT 0,
     correlation_id VARCHAR(255) UNIQUE,
-    status         VARCHAR(50)  NOT NULL DEFAULT 'PENDING',
+    status         ENUM('PENDING','PROCESSING','PUBLISHED','FAILED','DEAD_LETTERED')
+                   NOT NULL DEFAULT 'PENDING',
     failure_reason TEXT,
     next_retry_at  DATETIME,
 

--- a/src/main/resources/db/migration/V9__Create_payments_table.sql
+++ b/src/main/resources/db/migration/V9__Create_payments_table.sql
@@ -13,7 +13,7 @@ CREATE TABLE payments
     payment_method    VARCHAR(255) NOT NULL,
     pg_transaction_id VARCHAR(255) DEFAULT NULL,
     fail_reason       VARCHAR(255) DEFAULT NULL,
-    status ENUM('PENDING', 'COMPLETED', 'FAILED', 'CANCELED', 'REFUNDED', 'EXPIRED') NOT NULL,
+    status ENUM('PENDING', 'COMPLETED', 'FAILED', 'REFUNDED', 'EXPIRED') NOT NULL,
 
     UNIQUE KEY uq_payment_meeting_user (meeting_id, user_id)
 );


### PR DESCRIPTION
payment와 payment_outbox 테이블 엔티티와 ddl 데이터를 일치 시켜주었습니다