### PR TITLE
Elasticsearch - title, description에 따른 추천 API

### DIFF
--- a/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/application/MeetingServiceImpl.java
@@ -303,6 +303,11 @@ public class MeetingServiceImpl implements MeetingService {
 		meetingRepository.deleteMeetingElastic(meeting);
 	}
 
+	@Override
+	public List<MeetingDocument> getRecommendedMeetings(Long meetingId) {
+		return meetingRepository.getRecommendedMeetings(meetingId);
+	}
+
 	/**
 	 * Meeting Participant Service
 	 */

--- a/src/main/java/com/example/momo/domain/meeting/domain/MeetingRepository.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/MeetingRepository.java
@@ -26,6 +26,8 @@ public interface MeetingRepository {
 
 	List<Meeting> findMeetingsByUserId(Long userId);
 
+	List<MeetingDocument> getRecommendedMeetings(Long meetingId);
+
 	void saveMeetingElastic(Meeting meeting);
 
 	void deleteMeetingElastic(Meeting meeting);

--- a/src/main/java/com/example/momo/domain/meeting/domain/MeetingService.java
+++ b/src/main/java/com/example/momo/domain/meeting/domain/MeetingService.java
@@ -40,6 +40,8 @@ public interface MeetingService {
 
 	void deleteElasticMeeting(Meeting meeting);
 
+	List<MeetingDocument> getRecommendedMeetings(Long meetingId);
+
 	/** Meeting Participant Service */
 
 	ParticipantCreateResponseDto createParticipant(Long userId, Long meetingId);

--- a/src/main/java/com/example/momo/domain/meeting/infra/MeetingElasticCustomRepository.java
+++ b/src/main/java/com/example/momo/domain/meeting/infra/MeetingElasticCustomRepository.java
@@ -1,6 +1,7 @@
 package com.example.momo.domain.meeting.infra;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,4 +14,6 @@ public interface MeetingElasticCustomRepository {
 	Page<MeetingDocument> getMeetings(String title, LocalDateTime meetingDate,
 		MeetingStatus status, Integer categoryId,
 		Pageable pageable);
+
+	List<MeetingDocument> getRecommendedMeetings(Long meetingId);
 }

--- a/src/main/java/com/example/momo/domain/meeting/infra/MeetingElasticCustomRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/infra/MeetingElasticCustomRepositoryImpl.java
@@ -6,12 +6,15 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.query.Criteria;
 import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 import com.example.momo.domain.meeting.domain.MeetingDocument;
@@ -61,5 +64,35 @@ public class MeetingElasticCustomRepositoryImpl implements MeetingElasticCustomR
 			.collect(Collectors.toList());
 
 		return new PageImpl<>(content, pageable, searchHits.getTotalHits());
+	}
+
+	@Override
+	public List<MeetingDocument> getRecommendedMeetings(Long meetingId) {
+
+		System.out.println("[TEST] getRecommendedMeetings start");
+
+		Query query = NativeQuery.builder()
+			.withQuery(q -> q.bool(b -> b
+				.must(m -> m.moreLikeThis(mlt -> mlt
+					.fields("title", "description")
+					.like(l -> l.document(d -> d.index("meetings").id(meetingId.toString())))
+					.minTermFreq(1)
+					.minDocFreq(1)
+					.maxQueryTerms(50)
+					.minimumShouldMatch("30%")
+				))
+				.filter(f -> f.term(t -> t.field("status").value("IN_PROGRESS")))
+			))
+			.withPageable(PageRequest.of(0, 10))
+			.build();
+
+		SearchHits<MeetingDocument> searchHits = elasticsearchOperations.search(query, MeetingDocument.class);
+
+		System.out.println("[TEST] getRecommendedMeetings end");
+
+		return searchHits.getSearchHits()
+			.stream()
+			.map(SearchHit::getContent)
+			.toList();
 	}
 }

--- a/src/main/java/com/example/momo/domain/meeting/infra/MeetingRepositoryImpl.java
+++ b/src/main/java/com/example/momo/domain/meeting/infra/MeetingRepositoryImpl.java
@@ -49,7 +49,7 @@ public class MeetingRepositoryImpl implements MeetingRepository {
 	@Override
 	public Page<Meeting> getMeetingsForDatabase(String title, LocalDateTime meetingDate, MeetingStatus status,
 		Integer categoryId, Pageable pageable) {
-		
+
 		return meetingQueryRepository.getMeetings(title, meetingDate, status, categoryId, pageable);
 	}
 
@@ -73,6 +73,11 @@ public class MeetingRepositoryImpl implements MeetingRepository {
 	@Override
 	public List<Meeting> findMeetingsByUserId(Long userId) {
 		return meetingQueryRepository.findMeetingsByUserId(userId);
+	}
+
+	@Override
+	public List<MeetingDocument> getRecommendedMeetings(Long meetingId) {
+		return meetingElasticCustomRepository.getRecommendedMeetings(meetingId);
 	}
 
 	/* Meeting Participant Repository */

--- a/src/main/java/com/example/momo/domain/meeting/presentation/MeetingController.java
+++ b/src/main/java/com/example/momo/domain/meeting/presentation/MeetingController.java
@@ -109,6 +109,13 @@ public class MeetingController {
 		return ResponseEntity.ok(ApiResponse.success("유저 식별자를 통한 모임 목록 조회가 성공적으로 완료되었습니다.", response));
 	}
 
+	@GetMapping("/{meetingId}/recommendations")
+	public ResponseEntity<ApiResponse<List<MeetingDocument>>> getRecommendedMeetings(@PathVariable Long meetingId) {
+
+		List<MeetingDocument> response = meetingService.getRecommendedMeetings(meetingId);
+		return ResponseEntity.ok(ApiResponse.success("조회한 데이터에 맞는 추천 모임 목록 조회입니다.", response));
+	}
+
 	// 모임 참가
 	@PostMapping("/{meetingId}/participants")
 	public ResponseEntity<ApiResponse<ParticipantCreateResponseDto>> createParticipant(


### PR DESCRIPTION
### 구현 기능
- meetingId를 통한 추천 로직
  - title, description 추천 - 10개
  - status 진행중 상태만 필터링
  - MoreLikeQuery를 이용하여 meetingId와 비교하여 반환
  
### 참고 사항
- 위도 경도를 포함한 필터링은 Document 수정이 필요하여 진행하지 않았습니다.